### PR TITLE
[OGD-17] 배포서버에서 컨테이너 이미지(과거) 삭제가되지 않는 오류 수정

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -114,22 +114,27 @@ jobs:
               exit 1
             fi
 
-            # Clean up old Docker images
+            # Clean up old Docker images (keep only current)
             echo "🧹 Cleaning up old Docker images..."
 
-            # Get current image ID
-            CURRENT_IMAGE_ID=$(docker images "$TARGET_IMAGE" --format "{{.ID}}" | head -n 1)
-            echo "Current image ID: $CURRENT_IMAGE_ID"
+            # Get current running container's image ID
+            CURRENT_IMAGE_ID=$(docker inspect "$CONTAINER_NAME" --format='{{.Image}}' 2>/dev/null || echo "")
 
-            # Get all images for this repository (excluding the current one)
-            OLD_IMAGES=$(docker images "$REGISTRY/$DOCKER_USERNAME/$IMAGE_NAME" --format "{{.ID}} {{.Tag}}" | grep -v "$CURRENT_IMAGE_ID" | head -n -1 | awk '{print $1}')
+            if [ -n "$CURRENT_IMAGE_ID" ]; then
+              echo "Current container image ID: $CURRENT_IMAGE_ID"
 
-            if [ -n "$OLD_IMAGES" ]; then
-              echo "Removing old images (keeping 1 backup):"
-              echo "$OLD_IMAGES"
-              echo "$OLD_IMAGES" | xargs -r docker rmi -f || true
+              # Remove all juni416/stock-diary images except the current one
+              OLD_IMAGES=$(docker images juni416/stock-diary --format "{{.ID}}" | grep -v "$CURRENT_IMAGE_ID" || echo "")
+
+              if [ -n "$OLD_IMAGES" ]; then
+                echo "Removing old images (keeping only current):"
+                echo "$OLD_IMAGES"
+                echo "$OLD_IMAGES" | xargs -r docker rmi -f || true
+              else
+                echo "No old images to clean up"
+              fi
             else
-              echo "No old images to clean up"
+              echo "⚠️ Could not get current container image ID"
             fi
 
             # Clean up dangling images
@@ -235,22 +240,27 @@ jobs:
               exit 1
             fi
 
-            # Clean up old Docker images
+            # Clean up old Docker images (keep only current)
             echo "🧹 Cleaning up old Docker images..."
 
-            # Get current image ID
-            CURRENT_IMAGE_ID=$(docker images "$TARGET_IMAGE" --format "{{.ID}}" | head -n 1)
-            echo "Current image ID: $CURRENT_IMAGE_ID"
+            # Get current running container's image ID
+            CURRENT_IMAGE_ID=$(docker inspect "$CONTAINER_NAME" --format='{{.Image}}' 2>/dev/null || echo "")
 
-            # Get all images for this repository (excluding the current one)
-            OLD_IMAGES=$(docker images "$REGISTRY/$DOCKER_USERNAME/$IMAGE_NAME" --format "{{.ID}} {{.Tag}}" | grep -v "$CURRENT_IMAGE_ID" | head -n -1 | awk '{print $1}')
+            if [ -n "$CURRENT_IMAGE_ID" ]; then
+              echo "Current container image ID: $CURRENT_IMAGE_ID"
 
-            if [ -n "$OLD_IMAGES" ]; then
-              echo "Removing old images (keeping 1 backup):"
-              echo "$OLD_IMAGES"
-              echo "$OLD_IMAGES" | xargs -r docker rmi -f || true
+              # Remove all juni416/stock-diary images except the current one
+              OLD_IMAGES=$(docker images juni416/stock-diary --format "{{.ID}}" | grep -v "$CURRENT_IMAGE_ID" || echo "")
+
+              if [ -n "$OLD_IMAGES" ]; then
+                echo "Removing old images (keeping only current):"
+                echo "$OLD_IMAGES"
+                echo "$OLD_IMAGES" | xargs -r docker rmi -f || true
+              else
+                echo "No old images to clean up"
+              fi
             else
-              echo "No old images to clean up"
+              echo "⚠️ Could not get current container image ID"
             fi
 
             # Clean up dangling images

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -14,10 +14,10 @@ on:
 
 jobs:
   ci:
-    uses: ./.github/workflows/ci-container.yml
+    uses: ./.github/workflows/ci.yml
     secrets: inherit
 
   cd:
     needs: ci
-    uses: ./.github/workflows/cd-container.yml
+    uses: ./.github/workflows/cd.yml
     secrets: inherit


### PR DESCRIPTION
## 📌 관련 이슈
- Jira Ticket: [OGD-17](https://depromeet05.atlassian.net/browse/OGD-17)

## 🔍 PR의 이유
- 메모리 효율적으로 사용하기 위해 컨테이너 이미지를 삭제할 수 있어야 함

## ✨ 주요 변경사항
- [ ] 새 버전의 이미지만 존재할 수 있도록 변경

## 📎 참고(선택)
- ex) 관련 문서, 이슈 링크 등이 있다면 작성해주세요.