### PR TITLE
fix: PromptLoader bean 충돌 안하도록 이름 변경

### DIFF
--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/report/service/ReportService.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/report/service/ReportService.java
@@ -19,7 +19,7 @@ import com.ogd.stockdiary.domain.report.entity.RetrospectionForReport;
 import com.ogd.stockdiary.domain.report.port.in.CreateFeedbackCommand;
 import com.ogd.stockdiary.domain.report.port.in.CreateFeedbackUseCase;
 import com.ogd.stockdiary.domain.report.port.out.FeedbackRepository;
-import com.ogd.stockdiary.domain.report.port.out.PromptLoader;
+import com.ogd.stockdiary.domain.report.port.out.ReportPromptLoader;
 import com.ogd.stockdiary.domain.report.port.out.RetrospectionForReportRepository;
 import com.ogd.stockdiary.domain.retrospection.entity.Order;
 import com.ogd.stockdiary.domain.retrospection.entity.Retrospection;
@@ -34,7 +34,7 @@ public class ReportService implements CreateFeedbackUseCase {
     private final RetrospectionForReportRepository retrospectionForReportRepository;
     private final RetrospectionRepository retrospectionRepository;
     private final FeedbackRepository feedbackRepository;
-    private final PromptLoader promptLoader;
+    private final ReportPromptLoader reportPromptLoader;
     private final ChatModel chatModel;
 
     @Override
@@ -59,7 +59,7 @@ public class ReportService implements CreateFeedbackUseCase {
                 new SystemPromptTemplate(systemText)
                         .createMessage(Map.of("symbol", symbol, "market", market, "order", order));
 
-        Message userMessage = new UserMessage(promptLoader.getPrompt());
+        Message userMessage = new UserMessage(reportPromptLoader.getPrompt());
 
         OpenAiChatOptions options =
                 new OpenAiChatOptions.Builder().model(command.modelName()).maxTokens(200).build();

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/report/port/out/ReportPromptLoader.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/report/port/out/ReportPromptLoader.java
@@ -8,11 +8,11 @@ import lombok.Getter;
 
 @Getter
 @Component
-public class PromptLoader {
+public class ReportPromptLoader {
 
     private final String prompt;
 
-    public PromptLoader(ResourceLoader resourceLoader) throws Exception {
+    public ReportPromptLoader(ResourceLoader resourceLoader) throws Exception {
 
         Resource resource =
                 resourceLoader.getResource("classpath:RetrospectionForReportPrompt.txt");


### PR DESCRIPTION
## 📌 관련 이슈
- Jira Ticket: [OGD-15](https://depromeet05.atlassian.net/browse/OGD-15)

## 🔍 PR의 이유
- PromptLoader 가 현재 리포트 프롬프트 로더, 시장분석 프롬프트 로더 두 개라서 빈 충돌 

## ✨ 주요 변경사항
- [ ] 빈 이름 변경 

## 📎 참고(선택)
- ex) 관련 문서, 이슈 링크 등이 있다면 작성해주세요.