### PR TITLE
[OGD-28] 투자원칙 로직 및 테이블 수정

### DIFF
--- a/stock-diary/build.gradle
+++ b/stock-diary/build.gradle
@@ -71,13 +71,13 @@ dependencies {
 
 spotless {
     java {
-        // Google Java 포맷 적용
+        // Eclipse 포맷 적용
         /*
-            googleJavaFormat() : 탭은 2개의 공백
-            googleJavaFormat().aosp() : 탭은 4개의 공백
-            [참고] https://github.com/google/google-java-format/issues/525
+            탭: 4개의 공백
+            continuation indent: 4 (1x 기본 indent)
+            라인 길이: 120
          */
-        googleJavaFormat().aosp()
+        eclipse().configFile('eclipse-formatter.xml')
         // 아래 순서로 import문 정렬
         importOrder('java', 'javax', 'jakarta', 'org', 'com')
         // 사용하지 않는 import 제거

--- a/stock-diary/eclipse-formatter.xml
+++ b/stock-diary/eclipse-formatter.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<profiles version="13">
+    <profile kind="CodeFormatterProfile" name="StockDiary" version="13">
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_invocation_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="space"/>
+        <setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="4"/>
+        <setting id="org.eclipse.jdt.core.formatter.indentation.size" value="4"/>
+        <setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_block" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_method_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_type_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_package" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_package" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_imports" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_at_end_of_file_if_missing" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.lineSplit" value="120"/>
+        <setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.join_lines_in_comments" value="false"/>
+    </profile>
+</profiles>

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/analysis/analysisImpl.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/analysis/analysisImpl.java
@@ -1,3 +1,4 @@
 package com.ogd.stockdiary.application.analysis;
 
-public class analysisImpl {}
+public class analysisImpl {
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/config/CacheConfig.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/config/CacheConfig.java
@@ -18,7 +18,7 @@ public class CacheConfig {
     public CacheManager cacheManager() {
         CaffeineCacheManager cacheManager = new CaffeineCacheManager();
         cacheManager.setCaffeine(
-                Caffeine.newBuilder().maximumSize(100).expireAfterWrite(30, TimeUnit.MINUTES));
+            Caffeine.newBuilder().maximumSize(100).expireAfterWrite(30, TimeUnit.MINUTES));
         return cacheManager;
     }
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/config/ControllerExceptionHandler.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/config/ControllerExceptionHandler.java
@@ -28,71 +28,70 @@ public class ControllerExceptionHandler {
     @ExceptionHandler(ApplicationException.class)
     public ResponseEntity handleApplicationException(ApplicationException e) {
         logger.error(
-                "Application Exception occurred. code={}, message={}",
-                e.getCode().name(),
-                e.getMessage());
+            "Application Exception occurred. code={}, message={}",
+            e.getCode().name(),
+            e.getMessage());
 
         if (e.getCode() == CodeEnum.FRS_002) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                    .body(
-                            HttpApiResponse.fromExceptionMessage(
-                                    e.getMessage() != null
-                                            ? e.getMessage()
-                                            : e.getCode().getDescription(),
-                                    e.getCode(),
-                                    e.getData()));
+                .body(
+                    HttpApiResponse.fromExceptionMessage(
+                        e.getMessage() != null
+                            ? e.getMessage()
+                            : e.getCode().getDescription(),
+                        e.getCode(),
+                        e.getData()));
         }
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(
-                        HttpApiResponse.fromExceptionMessage(
-                                e.getMessage() != null
-                                        ? e.getMessage()
-                                        : e.getCode().getDescription(),
-                                e.getCode(),
-                                e.getData()));
+            .body(
+                HttpApiResponse.fromExceptionMessage(
+                    e.getMessage() != null
+                        ? e.getMessage()
+                        : e.getCode().getDescription(),
+                    e.getCode(),
+                    e.getData()));
     }
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
     public ResponseEntity<HttpApiResponse<?>> handleMethodNotSupported(
-            HttpRequestMethodNotSupportedException e) {
+        HttpRequestMethodNotSupportedException e) {
         logger.error("HandlerExceptionResolver Exception occurred. message={}", e.getMessage(), e);
         return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED)
-                .body(
-                        HttpApiResponse.fromExceptionMessage(
-                                CodeEnum.FRS_005.getDescription(), CodeEnum.FRS_005, null));
+            .body(
+                HttpApiResponse.fromExceptionMessage(
+                    CodeEnum.FRS_005.getDescription(), CodeEnum.FRS_005, null));
     }
 
     @ExceptionHandler(ValidationException.class)
     public ResponseEntity<HttpApiResponse<?>> handleValidationException(ValidationException e) {
         logger.error("Validation Exception occurred. message={}", e.getMessage(), e);
-        String errorMessage =
-                (e.getMessage() != null && !e.getMessage().isBlank())
-                        ? e.getMessage()
-                        : CodeEnum.FRS_003.getDescription();
+        String errorMessage = (e.getMessage() != null && !e.getMessage().isBlank())
+            ? e.getMessage()
+            : CodeEnum.FRS_003.getDescription();
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(HttpApiResponse.fromExceptionMessage(CodeEnum.FRS_003, errorMessage + " | "));
+            .body(HttpApiResponse.fromExceptionMessage(CodeEnum.FRS_003, errorMessage + " | "));
     }
 
     @ExceptionHandler(MissingServletRequestParameterException.class)
     public ResponseEntity<HttpApiResponse<?>> handleMissingServletRequestParameterException(
-            MissingServletRequestParameterException e) {
+        MissingServletRequestParameterException e) {
         logger.error(
-                "MissingServletRequestParameter Exception occurred. parameterName={}, message={}",
-                e.getParameterName(),
-                e.getMessage(),
-                e);
+            "MissingServletRequestParameter Exception occurred. parameterName={}, message={}",
+            e.getParameterName(),
+            e.getMessage(),
+            e);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(HttpApiResponse.fromExceptionMessage(CodeEnum.FRS_003, e.getMessage()));
+            .body(HttpApiResponse.fromExceptionMessage(CodeEnum.FRS_003, e.getMessage()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<HttpApiResponse<?>> handleMethodArgumentNotValidException(
-            MethodArgumentNotValidException e) {
+        MethodArgumentNotValidException e) {
         logger.error("MethodArgumentNotValidException occurred. message={}", e.getMessage(), e);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(HttpApiResponse.fromExceptionMessage(CodeEnum.FRS_003, createMessage(e)));
+            .body(HttpApiResponse.fromExceptionMessage(CodeEnum.FRS_003, createMessage(e)));
     }
 
     private String createMessage(MethodArgumentNotValidException e) {
@@ -102,8 +101,7 @@ public class ControllerExceptionHandler {
         }
 
         List<FieldError> fieldErrors = e.getBindingResult().getFieldErrors();
-        String fields =
-                fieldErrors.stream().map(FieldError::getField).collect(Collectors.joining(", "));
+        String fields = fieldErrors.stream().map(FieldError::getField).collect(Collectors.joining(", "));
         return fields + " 값들이 정확하지 않습니다.";
     }
 
@@ -111,8 +109,8 @@ public class ControllerExceptionHandler {
     public ResponseEntity handleException(Exception e) {
         logger.error("Exception occurred. message={}", e.getMessage(), e);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(
-                        HttpApiResponse.fromExceptionMessage(
-                                CodeEnum.FRS_004, CodeEnum.FRS_004.getDescription()));
+            .body(
+                HttpApiResponse.fromExceptionMessage(
+                    CodeEnum.FRS_004, CodeEnum.FRS_004.getDescription()));
     }
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/config/SwaggerConfig.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/config/SwaggerConfig.java
@@ -10,12 +10,7 @@ import io.swagger.v3.oas.annotations.security.SecurityScheme;
 
 @Configuration
 @OpenAPIDefinition(info = @Info(title = "Stock Diary API", version = "1.0"))
-@SecurityScheme(
-        name = SwaggerConfig.SECURITY_SCHEME_NAME,
-        type = SecuritySchemeType.HTTP,
-        scheme = "bearer",
-        bearerFormat = "JWT",
-        description = "Token Authentication")
+@SecurityScheme(name = SwaggerConfig.SECURITY_SCHEME_NAME, type = SecuritySchemeType.HTTP, scheme = "bearer", bearerFormat = "JWT", description = "Token Authentication")
 public class SwaggerConfig {
     public static final String SECURITY_SCHEME_NAME = "BearerAuth";
 

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/controller/InvestmentPrincipleController.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/controller/InvestmentPrincipleController.java
@@ -6,6 +6,7 @@ import jakarta.validation.Valid;
 
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -17,6 +18,7 @@ import com.ogd.stockdiary.application.investmentprinciple.dto.mapper.InvestmentP
 import com.ogd.stockdiary.application.investmentprinciple.dto.request.BatchProcessRequest;
 import com.ogd.stockdiary.application.investmentprinciple.dto.request.CreateMultiplePrinciplesRequest;
 import com.ogd.stockdiary.application.investmentprinciple.dto.request.CreatePrincipleRequest;
+import com.ogd.stockdiary.application.investmentprinciple.dto.request.ReorderPrinciplesRequest;
 import com.ogd.stockdiary.application.investmentprinciple.dto.request.UpdatePrincipleRequest;
 import com.ogd.stockdiary.application.investmentprinciple.dto.response.BatchProcessResponse;
 import com.ogd.stockdiary.application.investmentprinciple.dto.response.InvestmentPrincipleResponse;
@@ -25,6 +27,7 @@ import com.ogd.stockdiary.domain.investmentprinciple.dto.BatchProcessCommand;
 import com.ogd.stockdiary.domain.investmentprinciple.dto.BatchProcessResult;
 import com.ogd.stockdiary.domain.investmentprinciple.dto.CreateMultiplePrinciplesCommand;
 import com.ogd.stockdiary.domain.investmentprinciple.dto.CreatePrincipleCommand;
+import com.ogd.stockdiary.domain.investmentprinciple.dto.ReorderPrinciplesCommand;
 import com.ogd.stockdiary.domain.investmentprinciple.dto.UpdatePrincipleCommand;
 import com.ogd.stockdiary.domain.investmentprinciple.entity.InvestmentPrinciple;
 import com.ogd.stockdiary.domain.investmentprinciple.usecase.InvestmentPrincipleUseCase;
@@ -49,16 +52,15 @@ public class InvestmentPrincipleController {
         Long userId = 1L; // 임시로 하드코딩
 
         List<InvestmentPrinciple> principles = investmentPrincipleUseCase.getUserPrinciples(userId);
-        List<InvestmentPrincipleResponse> responses =
-                InvestmentPrincipleMapper.toResponseList(principles);
+        List<InvestmentPrincipleResponse> responses = InvestmentPrincipleMapper.toResponseList(principles);
 
         return HttpApiResponse.of(responses);
     }
 
     @PostMapping
-    @Operation(summary = "투자원칙 생성", description = "새로운 투자원칙을 생성합니다.")
+    @Operation(summary = "투자원칙 생성", description = "새로운 투자원칙을 생성합니다. 그룹에 속한 원칙은 최대 5개까지만 가능합니다.")
     public HttpApiResponse<InvestmentPrincipleResponse> createPrinciple(
-            @Valid @RequestBody CreatePrincipleRequest request) {
+        @Valid @RequestBody CreatePrincipleRequest request) {
 
         // TODO: Spring Security에서 User 정보 가져오기
         Long userId = 1L; // 임시로 하드코딩
@@ -73,17 +75,14 @@ public class InvestmentPrincipleController {
     @PostMapping("/multiple")
     @Operation(summary = "다중 투자원칙 생성", description = "여러 투자원칙을 한번에 생성합니다.")
     public HttpApiResponse<List<InvestmentPrincipleResponse>> createMultiplePrinciples(
-            @Valid @RequestBody CreateMultiplePrinciplesRequest request) {
+        @Valid @RequestBody CreateMultiplePrinciplesRequest request) {
 
         // TODO: Spring Security에서 User 정보 가져오기
         Long userId = 1L; // 임시로 하드코딩
 
-        CreateMultiplePrinciplesCommand command =
-                InvestmentPrincipleMapper.toCommand(request, userId);
-        List<InvestmentPrinciple> principles =
-                investmentPrincipleUseCase.createMultiplePrinciples(command);
-        List<InvestmentPrincipleResponse> responses =
-                InvestmentPrincipleMapper.toResponseList(principles);
+        CreateMultiplePrinciplesCommand command = InvestmentPrincipleMapper.toCommand(request, userId);
+        List<InvestmentPrinciple> principles = investmentPrincipleUseCase.createMultiplePrinciples(command);
+        List<InvestmentPrincipleResponse> responses = InvestmentPrincipleMapper.toResponseList(principles);
 
         return HttpApiResponse.of(responses);
     }
@@ -91,13 +90,12 @@ public class InvestmentPrincipleController {
     @PutMapping("/{principleId}")
     @Operation(summary = "투자원칙 수정", description = "투자원칙의 내용을 수정합니다.")
     public HttpApiResponse<InvestmentPrincipleResponse> updatePrinciple(
-            @PathVariable Long principleId, @Valid @RequestBody UpdatePrincipleRequest request) {
+        @PathVariable Long principleId, @Valid @RequestBody UpdatePrincipleRequest request) {
 
         // TODO: Spring Security에서 User 정보 가져오기
         Long userId = 1L; // 임시로 하드코딩
 
-        UpdatePrincipleCommand command =
-                InvestmentPrincipleMapper.toCommand(request, principleId, userId);
+        UpdatePrincipleCommand command = InvestmentPrincipleMapper.toCommand(request, principleId, userId);
         InvestmentPrinciple principle = investmentPrincipleUseCase.updatePrinciple(command);
         InvestmentPrincipleResponse response = InvestmentPrincipleMapper.toResponse(principle);
 
@@ -113,13 +111,13 @@ public class InvestmentPrincipleController {
 
         investmentPrincipleUseCase.deletePrinciple(principleId, userId);
 
-        return HttpApiResponse.of(null);
+        return HttpApiResponse.of("success");
     }
 
     @PostMapping("/batch")
     @Operation(summary = "투자원칙 일괄 처리", description = "투자원칙을 생성/수정/삭제를 한번에 처리합니다.")
     public HttpApiResponse<BatchProcessResponse> batchProcessPrinciples(
-            @Valid @RequestBody BatchProcessRequest request) {
+        @Valid @RequestBody BatchProcessRequest request) {
 
         // TODO: Spring Security에서 User 정보 가져오기
         Long userId = 1L; // 임시로 하드코딩
@@ -129,5 +127,19 @@ public class InvestmentPrincipleController {
         BatchProcessResponse response = InvestmentPrincipleMapper.toBatchResponse(result);
 
         return HttpApiResponse.of(response);
+    }
+
+    @PatchMapping("/reorder")
+    @Operation(summary = "투자원칙 순서 변경", description = "여러 투자원칙의 표시 순서를 한번에 변경합니다.")
+    public HttpApiResponse<Void> reorderPrinciples(
+        @Valid @RequestBody ReorderPrinciplesRequest request) {
+
+        // TODO: Spring Security에서 User 정보 가져오기
+        Long userId = 1L; // 임시로 하드코딩
+
+        ReorderPrinciplesCommand command = InvestmentPrincipleMapper.toReorderCommand(request, userId);
+        investmentPrincipleUseCase.reorderPrinciples(command);
+
+        return HttpApiResponse.of("success");
     }
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/dto/mapper/InvestmentPrincipleMapper.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/dto/mapper/InvestmentPrincipleMapper.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 import com.ogd.stockdiary.application.investmentprinciple.dto.request.BatchProcessRequest;
 import com.ogd.stockdiary.application.investmentprinciple.dto.request.CreateMultiplePrinciplesRequest;
 import com.ogd.stockdiary.application.investmentprinciple.dto.request.CreatePrincipleRequest;
+import com.ogd.stockdiary.application.investmentprinciple.dto.request.ReorderPrinciplesRequest;
 import com.ogd.stockdiary.application.investmentprinciple.dto.request.UpdatePrincipleRequest;
 import com.ogd.stockdiary.application.investmentprinciple.dto.response.BatchProcessResponse;
 import com.ogd.stockdiary.application.investmentprinciple.dto.response.InvestmentPrincipleResponse;
@@ -13,65 +14,76 @@ import com.ogd.stockdiary.domain.investmentprinciple.dto.BatchProcessCommand;
 import com.ogd.stockdiary.domain.investmentprinciple.dto.BatchProcessResult;
 import com.ogd.stockdiary.domain.investmentprinciple.dto.CreateMultiplePrinciplesCommand;
 import com.ogd.stockdiary.domain.investmentprinciple.dto.CreatePrincipleCommand;
+import com.ogd.stockdiary.domain.investmentprinciple.dto.ReorderPrinciplesCommand;
 import com.ogd.stockdiary.domain.investmentprinciple.dto.UpdatePrincipleCommand;
 import com.ogd.stockdiary.domain.investmentprinciple.entity.InvestmentPrinciple;
 
 public class InvestmentPrincipleMapper {
 
     public static CreatePrincipleCommand toCommand(CreatePrincipleRequest request, Long userId) {
-        return new CreatePrincipleCommand(userId, request.getPrinciple());
+        return new CreatePrincipleCommand(
+            userId, request.getGroupId(), request.getPrinciple(), request.getDisplayOrder());
     }
 
     public static CreateMultiplePrinciplesCommand toCommand(
-            CreateMultiplePrinciplesRequest request, Long userId) {
+        CreateMultiplePrinciplesRequest request, Long userId) {
         return new CreateMultiplePrinciplesCommand(userId, request.getPrinciples());
     }
 
     public static UpdatePrincipleCommand toCommand(
-            UpdatePrincipleRequest request, Long principleId, Long userId) {
+        UpdatePrincipleRequest request, Long principleId, Long userId) {
         return new UpdatePrincipleCommand(principleId, userId, request.getPrinciple());
     }
 
     public static BatchProcessCommand toCommand(BatchProcessRequest request, Long userId) {
         List<UpdatePrincipleCommand> updateCommands = null;
         if (request.getUpdatePrinciples() != null) {
-            updateCommands =
-                    request.getUpdatePrinciples().stream()
-                            .map(
-                                    update ->
-                                            new UpdatePrincipleCommand(
-                                                    update.getPrincipleId(),
-                                                    userId,
-                                                    update.getPrinciple()))
-                            .collect(Collectors.toList());
+            updateCommands = request.getUpdatePrinciples().stream()
+                .map(
+                    update -> new UpdatePrincipleCommand(
+                        update.getPrincipleId(),
+                        userId,
+                        update.getPrinciple()))
+                .collect(Collectors.toList());
         }
 
         return new BatchProcessCommand(
-                userId,
-                request.getCreatePrinciples(),
-                updateCommands,
-                request.getDeletePrincipleIds());
+            userId,
+            request.getCreatePrinciples(),
+            updateCommands,
+            request.getDeletePrincipleIds());
     }
 
     public static InvestmentPrincipleResponse toResponse(InvestmentPrinciple principle) {
+        Long groupId = principle.getPrincipleGroup() != null
+            ? principle.getPrincipleGroup().getId()
+            : null;
         return new InvestmentPrincipleResponse(
-                principle.getId(),
-                principle.getPrinciple(),
-                principle.getCreatedAt(),
-                principle.getUpdatedAt());
+            principle.getId(), groupId, principle.getPrinciple(), principle.getDisplayOrder());
     }
 
     public static List<InvestmentPrincipleResponse> toResponseList(
-            List<InvestmentPrinciple> principles) {
+        List<InvestmentPrinciple> principles) {
         return principles.stream()
-                .map(InvestmentPrincipleMapper::toResponse)
-                .collect(Collectors.toList());
+            .map(InvestmentPrincipleMapper::toResponse)
+            .collect(Collectors.toList());
     }
 
     public static BatchProcessResponse toBatchResponse(BatchProcessResult result) {
         return new BatchProcessResponse(
-                toResponseList(result.getCreatedPrinciples()),
-                toResponseList(result.getUpdatedPrinciples()),
-                result.getDeletedPrincipleIds());
+            toResponseList(result.getCreatedPrinciples()),
+            toResponseList(result.getUpdatedPrinciples()),
+            result.getDeletedPrincipleIds());
+    }
+
+    public static ReorderPrinciplesCommand toReorderCommand(
+        ReorderPrinciplesRequest request, Long userId) {
+        List<ReorderPrinciplesCommand.PrincipleOrder> principleOrders = request.getPrincipleOrders().stream()
+            .map(
+                order -> new ReorderPrinciplesCommand.PrincipleOrder(
+                    order.getPrincipleId(), order.getDisplayOrder()))
+            .collect(Collectors.toList());
+
+        return new ReorderPrinciplesCommand(userId, principleOrders);
     }
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/dto/request/BatchProcessRequest.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/dto/request/BatchProcessRequest.java
@@ -11,19 +11,13 @@ import lombok.NoArgsConstructor;
 @Schema(description = "투자원칙 일괄 처리 요청 정보")
 public class BatchProcessRequest {
 
-    @Schema(
-            description = "생성할 투자원칙 목록",
-            example = "[\"손절매는 반드시 10% 이내에서\", \"분산투자로 위험 관리\"]",
-            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @Schema(description = "생성할 투자원칙 목록", example = "[\"손절매는 반드시 10% 이내에서\", \"분산투자로 위험 관리\"]", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private List<String> createPrinciples;
 
     @Schema(description = "수정할 투자원칙 목록", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private List<UpdateRequest> updatePrinciples;
 
-    @Schema(
-            description = "삭제할 투자원칙 ID 목록",
-            example = "[1, 2, 3]",
-            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @Schema(description = "삭제할 투자원칙 ID 목록", example = "[1, 2, 3]", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private List<Long> deletePrincipleIds;
 
     @Getter
@@ -33,10 +27,7 @@ public class BatchProcessRequest {
         @Schema(description = "투자원칙 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
         private Long principleId;
 
-        @Schema(
-                description = "수정할 투자원칙 내용",
-                example = "손절매는 반드시 5% 이내에서",
-                requiredMode = Schema.RequiredMode.REQUIRED)
+        @Schema(description = "수정할 투자원칙 내용", example = "손절매는 반드시 5% 이내에서", requiredMode = Schema.RequiredMode.REQUIRED)
         private String principle;
     }
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/dto/request/CreateMultiplePrinciplesRequest.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/dto/request/CreateMultiplePrinciplesRequest.java
@@ -14,10 +14,7 @@ import lombok.NoArgsConstructor;
 @Schema(description = "다중 투자원칙 생성 요청 정보")
 public class CreateMultiplePrinciplesRequest {
 
-    @Schema(
-            description = "투자원칙 목록",
-            example = "[\"손절매는 반드시 10% 이내에서\", \"매수 전 기업 재무제표 분석 필수\", \"분산투자로 위험 관리\"]",
-            requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(description = "투자원칙 목록", example = "[\"손절매는 반드시 10% 이내에서\", \"매수 전 기업 재무제표 분석 필수\", \"분산투자로 위험 관리\"]", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotNull(message = "투자원칙 목록은 필수입니다.")
     @NotEmpty(message = "투자원칙은 최소 1개 이상이어야 합니다.")
     private List<String> principles;

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/dto/request/CreatePrincipleRequest.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/dto/request/CreatePrincipleRequest.java
@@ -11,10 +11,13 @@ import lombok.NoArgsConstructor;
 @Schema(description = "투자원칙 생성 요청 정보")
 public class CreatePrincipleRequest {
 
-    @Schema(
-            description = "투자원칙 내용",
-            example = "손절매는 반드시 10% 이내에서",
-            requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(description = "투자원칙 그룹 ID (선택사항)", example = "1")
+    private Long groupId;
+
+    @Schema(description = "투자원칙 내용", example = "손절매는 반드시 10% 이내에서", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotBlank(message = "투자원칙 내용은 필수입니다.")
     private String principle;
+
+    @Schema(description = "그룹 내 표시 순서 (선택사항)", example = "0")
+    private Integer displayOrder;
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/dto/request/ReorderPrinciplesRequest.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/dto/request/ReorderPrinciplesRequest.java
@@ -1,0 +1,47 @@
+package com.ogd.stockdiary.application.investmentprinciple.dto.request;
+
+import java.util.List;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "투자원칙 순서 변경 요청 정보", example = """
+    {
+      "principleOrders": [
+        {"principleId": 1, "displayOrder": 0},
+        {"principleId": 2, "displayOrder": 1},
+        {"principleId": 3, "displayOrder": 2}
+      ]
+    }
+    """)
+public class ReorderPrinciplesRequest {
+
+    @Schema(description = "순서를 변경할 원칙 목록", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotEmpty(message = "순서를 변경할 원칙 목록은 필수입니다")
+    @Valid
+    private List<PrincipleOrder> principleOrders;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "원칙 순서 정보")
+    public static class PrincipleOrder {
+
+        @Schema(description = "원칙 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull(message = "원칙 ID는 필수입니다")
+        private Long principleId;
+
+        @Schema(description = "표시 순서", example = "0", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull(message = "표시 순서는 필수입니다")
+        private Integer displayOrder;
+    }
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/dto/request/UpdatePrincipleRequest.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/dto/request/UpdatePrincipleRequest.java
@@ -11,10 +11,7 @@ import lombok.NoArgsConstructor;
 @Schema(description = "투자원칙 수정 요청 정보")
 public class UpdatePrincipleRequest {
 
-    @Schema(
-            description = "수정할 투자원칙 내용",
-            example = "손절매는 반드시 5% 이내에서",
-            requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(description = "수정할 투자원칙 내용", example = "손절매는 반드시 5% 이내에서", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotBlank(message = "투자원칙 내용은 필수입니다.")
     private String principle;
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/dto/response/InvestmentPrincipleResponse.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/dto/response/InvestmentPrincipleResponse.java
@@ -1,7 +1,5 @@
 package com.ogd.stockdiary.application.investmentprinciple.dto.response;
 
-import java.time.LocalDateTime;
-
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -10,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 public class InvestmentPrincipleResponse {
 
     private final Long id;
+    private final Long groupId;
     private final String principle;
-    private final LocalDateTime createdAt;
-    private final LocalDateTime updatedAt;
+    private final Integer displayOrder;
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/repository/InvestmentPrincipleRepositoryImpl.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/repository/InvestmentPrincipleRepositoryImpl.java
@@ -45,4 +45,15 @@ public class InvestmentPrincipleRepositoryImpl implements InvestmentPrincipleRep
     public void deleteAllByIdInAndUserId(List<Long> principleIds, Long userId) {
         jpaInvestmentPrincipleRepository.deleteAllByIdInAndUserId(principleIds, userId);
     }
+
+    @Override
+    public List<InvestmentPrinciple> findByPrincipleGroupId(Long groupId) {
+        return jpaInvestmentPrincipleRepository.findByPrincipleGroupIdOrderByDisplayOrderAsc(
+            groupId);
+    }
+
+    @Override
+    public void deleteByPrincipleGroupId(Long groupId) {
+        jpaInvestmentPrincipleRepository.deleteByPrincipleGroupId(groupId);
+    }
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/repository/JpaInvestmentPrincipleRepository.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/repository/JpaInvestmentPrincipleRepository.java
@@ -23,8 +23,13 @@ public interface JpaInvestmentPrincipleRepository extends JpaRepository<Investme
     void deleteByIdAndUserId(@Param("principleId") Long principleId, @Param("userId") Long userId);
 
     @Modifying
-    @Query(
-            "DELETE FROM InvestmentPrinciple ip WHERE ip.id IN :principleIds AND ip.user.id = :userId")
+    @Query("DELETE FROM InvestmentPrinciple ip WHERE ip.id IN :principleIds AND ip.user.id = :userId")
     void deleteAllByIdInAndUserId(
-            @Param("principleIds") List<Long> principleIds, @Param("userId") Long userId);
+        @Param("principleIds") List<Long> principleIds, @Param("userId") Long userId);
+
+    List<InvestmentPrinciple> findByPrincipleGroupIdOrderByDisplayOrderAsc(Long groupId);
+
+    @Modifying
+    @Query("DELETE FROM InvestmentPrinciple ip WHERE ip.principleGroup.id = :groupId")
+    void deleteByPrincipleGroupId(@Param("groupId") Long groupId);
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/principlegroup/controller/PrincipleGroupController.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/principlegroup/controller/PrincipleGroupController.java
@@ -1,0 +1,146 @@
+package com.ogd.stockdiary.application.principlegroup.controller;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import jakarta.validation.Valid;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ogd.stockdiary.application.principlegroup.dto.mapper.PrincipleGroupMapper;
+import com.ogd.stockdiary.application.principlegroup.dto.request.CreatePrincipleGroupRequest;
+import com.ogd.stockdiary.application.principlegroup.dto.request.ReorderPrincipleGroupsRequest;
+import com.ogd.stockdiary.application.principlegroup.dto.request.UpdatePrincipleGroupRequest;
+import com.ogd.stockdiary.application.principlegroup.dto.response.PrincipleGroupResponse;
+import com.ogd.stockdiary.common.httpresponse.HttpApiResponse;
+import com.ogd.stockdiary.domain.investmentprinciple.entity.InvestmentPrinciple;
+import com.ogd.stockdiary.domain.investmentprinciple.port.out.InvestmentPrincipleRepository;
+import com.ogd.stockdiary.domain.principlegroup.dto.CreatePrincipleGroupCommand;
+import com.ogd.stockdiary.domain.principlegroup.dto.ReorderPrincipleGroupsCommand;
+import com.ogd.stockdiary.domain.principlegroup.dto.UpdatePrincipleGroupCommand;
+import com.ogd.stockdiary.domain.principlegroup.entity.PrincipleGroup;
+import com.ogd.stockdiary.domain.principlegroup.usecase.PrincipleGroupUseCase;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/principle-groups")
+@RequiredArgsConstructor
+@Tag(name = "Principle Group", description = "투자원칙 그룹 관리 API")
+public class PrincipleGroupController {
+
+    private final PrincipleGroupUseCase principleGroupUseCase;
+    private final InvestmentPrincipleRepository investmentPrincipleRepository;
+    private final PrincipleGroupMapper principleGroupMapper;
+
+    @GetMapping
+    @Operation(summary = "투자원칙 그룹 목록 조회", description = "사용자의 모든 투자원칙 그룹과 속한 원칙들을 조회합니다.")
+    public HttpApiResponse<List<PrincipleGroupResponse>> getUserPrincipleGroups() {
+
+        // TODO: Spring Security에서 User 정보 가져오기
+        Long userId = 1L; // 임시로 하드코딩
+
+        List<PrincipleGroup> principleGroups = principleGroupUseCase.getUserPrincipleGroups(userId);
+
+        List<PrincipleGroupResponse> responses = principleGroups.stream()
+            .sorted(Comparator.comparing(PrincipleGroup::getDisplayOrder))
+            .map(
+                group -> {
+                    List<InvestmentPrinciple> principles = investmentPrincipleRepository.findByPrincipleGroupId(
+                        group.getId());
+                    return principleGroupMapper.toResponse(group, principles);
+                })
+            .collect(Collectors.toList());
+
+        return HttpApiResponse.of(responses);
+    }
+
+    @GetMapping("/{groupId}")
+    @Operation(summary = "투자원칙 그룹 조회", description = "특정 투자원칙 그룹과 속한 원칙들을 조회합니다.")
+    public HttpApiResponse<PrincipleGroupResponse> getPrincipleGroupById(
+        @PathVariable Long groupId) {
+
+        // TODO: Spring Security에서 User 정보 가져오기
+        Long userId = 1L; // 임시로 하드코딩
+
+        PrincipleGroup principleGroup = principleGroupUseCase.getPrincipleGroupById(groupId, userId);
+
+        List<InvestmentPrinciple> principles = investmentPrincipleRepository
+            .findByPrincipleGroupId(principleGroup.getId());
+        PrincipleGroupResponse response = principleGroupMapper.toResponse(principleGroup, principles);
+
+        return HttpApiResponse.of(response);
+    }
+
+    @PostMapping
+    @Operation(summary = "투자원칙 그룹 생성", description = "새로운 투자원칙 그룹을 생성합니다. principles가 있으면 함께 생성됩니다. (최대 5개)")
+    public HttpApiResponse<PrincipleGroupResponse> createPrincipleGroup(
+        @Valid @RequestBody CreatePrincipleGroupRequest request) {
+
+        // TODO: Spring Security에서 User 정보 가져오기
+        Long userId = 1L; // 임시로 하드코딩
+
+        CreatePrincipleGroupCommand command = principleGroupMapper.toCommand(request, userId);
+        PrincipleGroup principleGroup = principleGroupUseCase.createPrincipleGroup(command);
+
+        List<InvestmentPrinciple> principles = investmentPrincipleRepository
+            .findByPrincipleGroupId(principleGroup.getId());
+        PrincipleGroupResponse response = principleGroupMapper.toResponse(principleGroup, principles);
+
+        return HttpApiResponse.of(response);
+    }
+
+    @PatchMapping("/{groupId}")
+    @Operation(summary = "투자원칙 그룹 수정", description = "투자원칙 그룹의 이름을 수정합니다.")
+    public HttpApiResponse<PrincipleGroupResponse> updatePrincipleGroup(
+        @PathVariable Long groupId, @Valid @RequestBody UpdatePrincipleGroupRequest request) {
+
+        // TODO: Spring Security에서 User 정보 가져오기
+        Long userId = 1L; // 임시로 하드코딩
+
+        UpdatePrincipleGroupCommand command = principleGroupMapper.toCommand(request, groupId, userId);
+        PrincipleGroup principleGroup = principleGroupUseCase.updatePrincipleGroup(command);
+
+        List<InvestmentPrinciple> principles = investmentPrincipleRepository
+            .findByPrincipleGroupId(principleGroup.getId());
+        PrincipleGroupResponse response = principleGroupMapper.toResponse(principleGroup, principles);
+
+        return HttpApiResponse.of(response);
+    }
+
+    @DeleteMapping("/{groupId}")
+    @Operation(summary = "투자원칙 그룹 삭제", description = "투자원칙 그룹과 해당 그룹에 속한 모든 원칙들을 삭제합니다.")
+    public HttpApiResponse<Void> deletePrincipleGroup(@PathVariable Long groupId) {
+
+        // TODO: Spring Security에서 User 정보 가져오기
+        Long userId = 1L; // 임시로 하드코딩
+
+        principleGroupUseCase.deletePrincipleGroup(groupId, userId);
+
+        return HttpApiResponse.of("success");
+    }
+
+    @PatchMapping("/reorder")
+    @Operation(summary = "투자원칙 그룹 순서 변경", description = "여러 투자원칙 그룹의 표시 순서를 한번에 변경합니다.")
+    public HttpApiResponse<Void> reorderPrincipleGroups(
+        @Valid @RequestBody ReorderPrincipleGroupsRequest request) {
+
+        // TODO: Spring Security에서 User 정보 가져오기
+        Long userId = 1L; // 임시로 하드코딩
+
+        ReorderPrincipleGroupsCommand command = principleGroupMapper.toReorderCommand(request, userId);
+        principleGroupUseCase.reorderPrincipleGroups(command);
+
+        return HttpApiResponse.of("success");
+    }
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/principlegroup/dto/mapper/PrincipleGroupMapper.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/principlegroup/dto/mapper/PrincipleGroupMapper.java
@@ -1,0 +1,65 @@
+package com.ogd.stockdiary.application.principlegroup.dto.mapper;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import com.ogd.stockdiary.application.investmentprinciple.dto.response.InvestmentPrincipleResponse;
+import com.ogd.stockdiary.application.principlegroup.dto.request.CreatePrincipleGroupRequest;
+import com.ogd.stockdiary.application.principlegroup.dto.request.ReorderPrincipleGroupsRequest;
+import com.ogd.stockdiary.application.principlegroup.dto.request.UpdatePrincipleGroupRequest;
+import com.ogd.stockdiary.application.principlegroup.dto.response.PrincipleGroupResponse;
+import com.ogd.stockdiary.domain.investmentprinciple.entity.InvestmentPrinciple;
+import com.ogd.stockdiary.domain.principlegroup.dto.CreatePrincipleGroupCommand;
+import com.ogd.stockdiary.domain.principlegroup.dto.ReorderPrincipleGroupsCommand;
+import com.ogd.stockdiary.domain.principlegroup.dto.UpdatePrincipleGroupCommand;
+import com.ogd.stockdiary.domain.principlegroup.entity.PrincipleGroup;
+
+@Component
+public class PrincipleGroupMapper {
+
+    public CreatePrincipleGroupCommand toCommand(CreatePrincipleGroupRequest request, Long userId) {
+        return new CreatePrincipleGroupCommand(
+            userId, request.getGroupName(), request.getDisplayOrder(), request.getPrinciples());
+    }
+
+    public UpdatePrincipleGroupCommand toCommand(
+        UpdatePrincipleGroupRequest request, Long groupId, Long userId) {
+        return new UpdatePrincipleGroupCommand(groupId, userId, request.getGroupName());
+    }
+
+    public ReorderPrincipleGroupsCommand toReorderCommand(
+        ReorderPrincipleGroupsRequest request, Long userId) {
+        List<ReorderPrincipleGroupsCommand.GroupOrder> groupOrders = request.getGroupOrders().stream()
+            .map(
+                order -> new ReorderPrincipleGroupsCommand.GroupOrder(
+                    order.getGroupId(), order.getDisplayOrder()))
+            .collect(Collectors.toList());
+
+        return new ReorderPrincipleGroupsCommand(userId, groupOrders);
+    }
+
+    public PrincipleGroupResponse toResponse(
+        PrincipleGroup principleGroup, List<InvestmentPrinciple> principles) {
+        List<InvestmentPrincipleResponse> principleResponses = principles.stream()
+            .map(
+                p -> {
+                    Long groupId = p.getPrincipleGroup() != null
+                        ? p.getPrincipleGroup().getId()
+                        : null;
+                    return new InvestmentPrincipleResponse(
+                        p.getId(),
+                        groupId,
+                        p.getPrinciple(),
+                        p.getDisplayOrder());
+                })
+            .collect(Collectors.toList());
+
+        return new PrincipleGroupResponse(
+            principleGroup.getId(),
+            principleGroup.getGroupName(),
+            principleGroup.getDisplayOrder(),
+            principleResponses);
+    }
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/principlegroup/dto/request/CreatePrincipleGroupRequest.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/principlegroup/dto/request/CreatePrincipleGroupRequest.java
@@ -1,0 +1,29 @@
+package com.ogd.stockdiary.application.principlegroup.dto.request;
+
+import java.util.List;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "투자원칙 그룹 생성 요청 정보")
+public class CreatePrincipleGroupRequest {
+
+    @Schema(description = "그룹명 (이모지 포함 가능)", example = "🔥 이건 좀 지키자 제발", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotBlank(message = "그룹명은 필수입니다")
+    private String groupName;
+
+    @Schema(description = "그룹 표시 순서", example = "1")
+    private Integer displayOrder;
+
+    @Schema(description = "그룹에 포함할 투자원칙 목록 (선택사항, 최대 5개)", example = "[\"안전마진을 확보하라\", \"기업의 본질 가치보다 낮게 거래되는 주식을 찾기\"]")
+    @Size(max = 5, message = "그룹당 최대 5개의 투자원칙만 추가할 수 있습니다")
+    private List<@NotBlank(message = "투자원칙 내용은 필수입니다") String> principles;
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/principlegroup/dto/request/ReorderPrincipleGroupsRequest.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/principlegroup/dto/request/ReorderPrincipleGroupsRequest.java
@@ -1,0 +1,47 @@
+package com.ogd.stockdiary.application.principlegroup.dto.request;
+
+import java.util.List;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "투자원칙 그룹 순서 변경 요청 정보", example = """
+    {
+      "groupOrders": [
+        {"groupId": 1, "displayOrder": 0},
+        {"groupId": 2, "displayOrder": 1},
+        {"groupId": 3, "displayOrder": 2}
+      ]
+    }
+    """)
+public class ReorderPrincipleGroupsRequest {
+
+    @Schema(description = "순서를 변경할 그룹 목록", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotEmpty(message = "순서를 변경할 그룹 목록은 필수입니다")
+    @Valid
+    private List<GroupOrder> groupOrders;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "그룹 순서 정보")
+    public static class GroupOrder {
+
+        @Schema(description = "그룹 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull(message = "그룹 ID는 필수입니다")
+        private Long groupId;
+
+        @Schema(description = "표시 순서", example = "0", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull(message = "표시 순서는 필수입니다")
+        private Integer displayOrder;
+    }
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/principlegroup/dto/request/UpdatePrincipleGroupRequest.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/principlegroup/dto/request/UpdatePrincipleGroupRequest.java
@@ -1,0 +1,19 @@
+package com.ogd.stockdiary.application.principlegroup.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "투자원칙 그룹 수정 요청 정보")
+public class UpdatePrincipleGroupRequest {
+
+    @Schema(description = "그룹명 (이모지 포함 가능)", example = "💪 초보자를 위한 매도 원칙", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotBlank(message = "그룹명은 필수입니다")
+    private String groupName;
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/principlegroup/dto/response/PrincipleGroupResponse.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/principlegroup/dto/response/PrincipleGroupResponse.java
@@ -1,0 +1,27 @@
+package com.ogd.stockdiary.application.principlegroup.dto.response;
+
+import java.util.List;
+
+import com.ogd.stockdiary.application.investmentprinciple.dto.response.InvestmentPrincipleResponse;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "투자원칙 그룹 응답 정보")
+public class PrincipleGroupResponse {
+
+    @Schema(description = "그룹 ID", example = "1")
+    private final Long id;
+
+    @Schema(description = "그룹명", example = "🔥 이건 좀 지키자 제발")
+    private final String groupName;
+
+    @Schema(description = "그룹 표시 순서", example = "1")
+    private final Integer displayOrder;
+
+    @Schema(description = "그룹에 속한 투자원칙 목록")
+    private final List<InvestmentPrincipleResponse> principles;
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/principlegroup/repository/JpaPrincipleGroupRepository.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/principlegroup/repository/JpaPrincipleGroupRepository.java
@@ -1,0 +1,17 @@
+package com.ogd.stockdiary.application.principlegroup.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.ogd.stockdiary.domain.principlegroup.entity.PrincipleGroup;
+
+public interface JpaPrincipleGroupRepository extends JpaRepository<PrincipleGroup, Long> {
+
+    List<PrincipleGroup> findByUserId(Long userId);
+
+    Optional<PrincipleGroup> findByIdAndUserId(Long id, Long userId);
+
+    void deleteByIdAndUserId(Long id, Long userId);
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/principlegroup/repository/PrincipleGroupRepositoryImpl.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/principlegroup/repository/PrincipleGroupRepositoryImpl.java
@@ -1,0 +1,38 @@
+package com.ogd.stockdiary.application.principlegroup.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+
+import com.ogd.stockdiary.domain.principlegroup.entity.PrincipleGroup;
+import com.ogd.stockdiary.domain.principlegroup.port.out.PrincipleGroupRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class PrincipleGroupRepositoryImpl implements PrincipleGroupRepository {
+
+    private final JpaPrincipleGroupRepository jpaPrincipleGroupRepository;
+
+    @Override
+    public List<PrincipleGroup> findByUserId(Long userId) {
+        return jpaPrincipleGroupRepository.findByUserId(userId);
+    }
+
+    @Override
+    public PrincipleGroup save(PrincipleGroup principleGroup) {
+        return jpaPrincipleGroupRepository.save(principleGroup);
+    }
+
+    @Override
+    public Optional<PrincipleGroup> findByIdAndUserId(Long groupId, Long userId) {
+        return jpaPrincipleGroupRepository.findByIdAndUserId(groupId, userId);
+    }
+
+    @Override
+    public void deleteByIdAndUserId(Long groupId, Long userId) {
+        jpaPrincipleGroupRepository.deleteByIdAndUserId(groupId, userId);
+    }
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/report/controller/ReportController.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/report/controller/ReportController.java
@@ -25,9 +25,9 @@ public class ReportController {
 
     @PostMapping("/{retrospectionId}/feedback")
     public ResponseEntity<HttpApiResponse<CreateFeedbackResponse>> CreateFeedback(
-            @RequestBody(required = false) CreateFeedbackRequest request,
-            @PathVariable Long retrospectionId)
-            throws JsonProcessingException {
+        @RequestBody(required = false) CreateFeedbackRequest request,
+        @PathVariable Long retrospectionId)
+        throws JsonProcessingException {
 
         // 요청을 command 객체로 변환
         CreateFeedbackCommand command = ReportMapper.toCommand(request, retrospectionId);

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/report/dto/Mapper/ReportMapper.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/report/dto/Mapper/ReportMapper.java
@@ -14,12 +14,12 @@ import com.ogd.stockdiary.domain.report.port.in.CreateFeedbackCommand;
 public class ReportMapper {
 
     public static CreateFeedbackCommand toCommand(
-            CreateFeedbackRequest request, Long retrospectionId) {
+        CreateFeedbackRequest request, Long retrospectionId) {
         return new CreateFeedbackCommand(retrospectionId);
     }
 
     public static CreateFeedbackResponse toResponse(Feedback feedback)
-            throws JsonProcessingException {
+        throws JsonProcessingException {
         ObjectMapper objectMapper = new ObjectMapper();
         List<Map<String, String>> principlesList = null;
 
@@ -27,12 +27,12 @@ public class ReportMapper {
         String principleJson = feedback.getPrinciples();
 
         // JSON 을 자바 객체로 파싱
-        principlesList =
-                objectMapper.readValue(
-                        principleJson, new TypeReference<List<Map<String, String>>>() {});
+        principlesList = objectMapper.readValue(
+            principleJson, new TypeReference<List<Map<String, String>>>() {
+            });
 
         return new CreateFeedbackResponse(
-                // 나머지 필드는 디비에 String 으로 저장되었었음
-                feedback.getSummerizedFeedback(), feedback.getMarket(), principlesList);
+            // 나머지 필드는 디비에 String 으로 저장되었었음
+            feedback.getSummerizedFeedback(), feedback.getMarket(), principlesList);
     }
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/report/dto/Request/CreateFeedbackRequest.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/report/dto/Request/CreateFeedbackRequest.java
@@ -1,3 +1,4 @@
 package com.ogd.stockdiary.application.report.dto.Request;
 
-public record CreateFeedbackRequest() {}
+public record CreateFeedbackRequest() {
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/report/dto/Response/CreateFeedbackResponse.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/report/dto/Response/CreateFeedbackResponse.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public record CreateFeedbackResponse(
-        @JsonProperty("요약 한 마디") String summerizedFeedback,
-        @JsonProperty("당시 시장 현황") String market,
-        @JsonProperty("AI 추천 원칙") List<Map<String, String>> principles) {}
+    @JsonProperty("요약 한 마디") String summerizedFeedback,
+    @JsonProperty("당시 시장 현황") String market,
+    @JsonProperty("AI 추천 원칙") List<Map<String, String>> principles) {
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/report/repository/JpaFeedbackRepository.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/report/repository/JpaFeedbackRepository.java
@@ -4,4 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.ogd.stockdiary.domain.report.entity.Feedback;
 
-public interface JpaFeedbackRepository extends JpaRepository<Feedback, Long> {}
+public interface JpaFeedbackRepository extends JpaRepository<Feedback, Long> {
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/report/repository/JpaRetrospectionForReportRepository.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/report/repository/JpaRetrospectionForReportRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.ogd.stockdiary.domain.report.entity.RetrospectionForReport;
 
 public interface JpaRetrospectionForReportRepository
-        extends JpaRepository<RetrospectionForReport, Long> {}
+    extends
+        JpaRepository<RetrospectionForReport, Long> {
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/report/repository/RetrospectionForReportRepositoryImpl.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/report/repository/RetrospectionForReportRepositoryImpl.java
@@ -17,13 +17,11 @@ public class RetrospectionForReportRepositoryImpl implements RetrospectionForRep
 
     @Override
     public RetrospectionForReport getById(Long id) {
-        RetrospectionForReport report =
-                jpaRetrospectionForReportRepository
-                        .findById(id)
-                        .orElseThrow(
-                                () ->
-                                        new ApplicationException(
-                                                CodeEnum.FRS_003, "회고를 찾을 수 없습니다" + id));
+        RetrospectionForReport report = jpaRetrospectionForReportRepository
+            .findById(id)
+            .orElseThrow(
+                () -> new ApplicationException(
+                    CodeEnum.FRS_003, "회고를 찾을 수 없습니다" + id));
 
         return report;
     }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/report/service/ReportService.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/report/service/ReportService.java
@@ -44,23 +44,22 @@ public class ReportService implements CreateFeedbackUseCase {
     @Override
     @Transactional
     public Feedback createFeedbackUseCase(CreateFeedbackCommand command)
-            throws JsonProcessingException {
+        throws JsonProcessingException {
 
         Retrospection retrospection = retrospectionRepository.getById(command.retrospectionId());
 
-        RetrospectionForReport retrospectionForReport =
-                retrospectionForReportRepository.getById(command.retrospectionId());
+        RetrospectionForReport retrospectionForReport = retrospectionForReportRepository
+            .getById(command.retrospectionId());
 
         String symbol = retrospectionForReport.getSymbol();
         String market = retrospectionForReport.getMarket();
         Order order = retrospectionForReport.getOrder();
         String content = retrospectionForReport.getContent();
-                
-        String userText =
-                """
-                Please analyze the symbol {symbol} in the {market} market based on the order: {order}.
-                This is user message : {content}.
-                """;
+
+        String userText = """
+            Please analyze the symbol {symbol} in the {market} market based on the order: {order}.
+            This is user message : {content}.
+            """;
 
         // 시스템 메시지를 로더에서 불러오기
         Message systemMessage = new SystemMessage(reportPromptLoader.getPrompt());
@@ -74,8 +73,7 @@ public class ReportService implements CreateFeedbackUseCase {
 
         String modelName = "gpt-4.1-nano";
 
-        OpenAiChatOptions options =
-                new OpenAiChatOptions.Builder().model(modelName).maxTokens(500).build();
+        OpenAiChatOptions options = new OpenAiChatOptions.Builder().model(modelName).maxTokens(500).build();
 
         Prompt prompt = new Prompt(List.of(systemMessage, userMessage), options);
 
@@ -91,14 +89,13 @@ public class ReportService implements CreateFeedbackUseCase {
         String principlesJson = objectMapper.writeValueAsString(dto.principles());
 
         // 피드백 객체 생성
-        Feedback feedback =
-                Feedback.builder()
-                        .feedback(text)
-                        .summerizedFeedback(dto.summerizedFeedback())
-                        .market(dto.market())
-                        .principles(principlesJson)
-                        .retrospection(retrospection)
-                        .build();
+        Feedback feedback = Feedback.builder()
+            .feedback(text)
+            .summerizedFeedback(dto.summerizedFeedback())
+            .market(dto.market())
+            .principles(principlesJson)
+            .retrospection(retrospection)
+            .build();
 
         // 저장
         feedbackRepository.save(feedback);

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/controller/RetrospectionController.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/controller/RetrospectionController.java
@@ -35,7 +35,7 @@ public class RetrospectionController {
     @PostMapping
     @Operation(summary = "회고 생성", description = "주식 거래 회고를 생성합니다.")
     public HttpApiResponse<CreateRetrospectionResponse> createRetrospection(
-            @Valid @RequestBody CreateRetrospectionRequest request) {
+        @Valid @RequestBody CreateRetrospectionRequest request) {
 
         // TODO: Spring Security에서 User 정보 가져오기
         Long userId = 1L; // 임시로 하드코딩
@@ -50,13 +50,12 @@ public class RetrospectionController {
     @GetMapping("/{retrospectionId}")
     @Operation(summary = "회고 조회", description = "특정 회고를 조회합니다.")
     public HttpApiResponse<GetRetrospectionResponse> getRetrospection(
-            @PathVariable Long retrospectionId) {
+        @PathVariable Long retrospectionId) {
 
         // TODO: Spring Security에서 User 정보 가져오기
         Long userId = 1L; // 임시로 하드코딩
 
-        GetRetrospectionResponse response =
-                getRetrospectionUseCase.getRetrospection(retrospectionId, userId);
+        GetRetrospectionResponse response = getRetrospectionUseCase.getRetrospection(retrospectionId, userId);
 
         return HttpApiResponse.of(response);
     }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/dto/mapper/RetrospectionMapper.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/dto/mapper/RetrospectionMapper.java
@@ -17,27 +17,26 @@ import com.ogd.stockdiary.domain.user.entity.User;
 public class RetrospectionMapper {
 
     public static CreateRetrospectionCommand toCommand(
-            CreateRetrospectionRequest request, Long userId) {
-        List<PrincipleCheckCommand> principleCheckCommands =
-                request.getPrincipleChecks() != null
-                        ? request.getPrincipleChecks().stream()
-                                .map(RetrospectionMapper::toPrincipleCheckCommand)
-                                .toList()
-                        : Collections.emptyList();
+        CreateRetrospectionRequest request, Long userId) {
+        List<PrincipleCheckCommand> principleCheckCommands = request.getPrincipleChecks() != null
+            ? request.getPrincipleChecks().stream()
+                .map(RetrospectionMapper::toPrincipleCheckCommand)
+                .toList()
+            : Collections.emptyList();
 
         return new CreateRetrospectionCommand(
-                userId,
-                request.getSymbol(),
-                request.getMarket(),
-                request.getOrderType(),
-                request.getPrice(),
-                request.getCurrency(),
-                request.getVolume(),
-                request.getOrderDate(),
-                request.getReturnRate(),
-                request.getContent(),
-                request.getEmotion(),
-                principleCheckCommands);
+            userId,
+            request.getSymbol(),
+            request.getMarket(),
+            request.getOrderType(),
+            request.getPrice(),
+            request.getCurrency(),
+            request.getVolume(),
+            request.getOrderDate(),
+            request.getReturnRate(),
+            request.getContent(),
+            request.getEmotion(),
+            principleCheckCommands);
     }
 
     private static PrincipleCheckCommand toPrincipleCheckCommand(PrincipleCheckRequest request) {
@@ -46,68 +45,65 @@ public class RetrospectionMapper {
 
     public static CreateRetrospectionResponse toResponse(Retrospection retrospection) {
         return new CreateRetrospectionResponse(
-                retrospection.getId(),
-                retrospection.getUser().getId(),
-                retrospection.getSymbol(),
-                retrospection.getMarket(),
-                retrospection.getOrder().getOrderType(),
-                retrospection.getOrder().getPrice(),
-                retrospection.getOrder().getCurrency(),
-                retrospection.getOrder().getVolume(),
-                retrospection.getOrder().getOrderDate(),
-                retrospection.getReturnRate(),
-                retrospection.getContent(),
-                retrospection.getEmotion(),
-                retrospection.getCreatedAt(),
-                retrospection.getUpdatedAt());
+            retrospection.getId(),
+            retrospection.getUser().getId(),
+            retrospection.getSymbol(),
+            retrospection.getMarket(),
+            retrospection.getOrder().getOrderType(),
+            retrospection.getOrder().getPrice(),
+            retrospection.getOrder().getCurrency(),
+            retrospection.getOrder().getVolume(),
+            retrospection.getOrder().getOrderDate(),
+            retrospection.getReturnRate(),
+            retrospection.getContent(),
+            retrospection.getEmotion(),
+            retrospection.getCreatedAt(),
+            retrospection.getUpdatedAt());
     }
 
     public static Retrospection toEntity(CreateRetrospectionCommand command, User user) {
-        Order order =
-                new Order(
-                        command.getOrderType(),
-                        command.getPrice(),
-                        command.getCurrency(),
-                        command.getVolume(),
-                        command.getOrderDate());
+        Order order = new Order(
+            command.getOrderType(),
+            command.getPrice(),
+            command.getCurrency(),
+            command.getVolume(),
+            command.getOrderDate());
 
         return new Retrospection(
-                user,
-                command.getSymbol(),
-                command.getMarket(),
-                order,
-                command.getReturnRate(),
-                command.getContent(),
-                command.getEmotion());
+            user,
+            command.getSymbol(),
+            command.getMarket(),
+            order,
+            command.getReturnRate(),
+            command.getContent(),
+            command.getEmotion());
     }
 
     public static GetRetrospectionResponse toGetResponse(
-            Retrospection retrospection, List<PrincipleCheck> principleChecks) {
-        List<GetRetrospectionResponse.PrincipleCheckResponse> principleCheckResponses =
-                principleChecks.stream()
-                        .map(
-                                pc ->
-                                        new GetRetrospectionResponse.PrincipleCheckResponse(
-                                                pc.getPrinciple().getId(),
-                                                pc.getPrinciple().getPrinciple(),
-                                                pc.getIsFollowed()))
-                        .toList();
+        Retrospection retrospection, List<PrincipleCheck> principleChecks) {
+        List<GetRetrospectionResponse.PrincipleCheckResponse> principleCheckResponses = principleChecks.stream()
+            .map(
+                pc -> new GetRetrospectionResponse.PrincipleCheckResponse(
+                    pc.getPrinciple().getId(),
+                    pc.getPrinciple().getPrinciple(),
+                    pc.getIsFollowed()))
+            .toList();
 
         return new GetRetrospectionResponse(
-                retrospection.getId(),
-                retrospection.getUser().getId(),
-                retrospection.getSymbol(),
-                retrospection.getMarket(),
-                retrospection.getOrder().getOrderType(),
-                retrospection.getOrder().getPrice(),
-                retrospection.getOrder().getCurrency(),
-                retrospection.getOrder().getVolume(),
-                retrospection.getOrder().getOrderDate(),
-                retrospection.getReturnRate(),
-                retrospection.getContent(),
-                retrospection.getEmotion(),
-                principleCheckResponses,
-                retrospection.getCreatedAt(),
-                retrospection.getUpdatedAt());
+            retrospection.getId(),
+            retrospection.getUser().getId(),
+            retrospection.getSymbol(),
+            retrospection.getMarket(),
+            retrospection.getOrder().getOrderType(),
+            retrospection.getOrder().getPrice(),
+            retrospection.getOrder().getCurrency(),
+            retrospection.getOrder().getVolume(),
+            retrospection.getOrder().getOrderDate(),
+            retrospection.getReturnRate(),
+            retrospection.getContent(),
+            retrospection.getEmotion(),
+            principleCheckResponses,
+            retrospection.getCreatedAt(),
+            retrospection.getUpdatedAt());
     }
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/dto/request/CreateRetrospectionRequest.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/dto/request/CreateRetrospectionRequest.java
@@ -50,20 +50,14 @@ public class CreateRetrospectionRequest {
     @Positive(message = "거래량은 0보다 큰 값이어야 합니다")
     private Integer volume;
 
-    @Schema(
-            description = "주문 날짜",
-            example = "2025-09-13",
-            requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(description = "주문 날짜", example = "2025-09-13", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotNull(message = "주문 날짜는 필수입니다")
     private LocalDate orderDate;
 
     @Schema(description = "수익률", example = "-15.67", requiredMode = RequiredMode.NOT_REQUIRED)
     private Double returnRate;
 
-    @Schema(
-            description = "회고 내용",
-            example = "이번 매도는 시장 상황을 잘 반영한 결정이었다.",
-            requiredMode = RequiredMode.NOT_REQUIRED)
+    @Schema(description = "회고 내용", example = "이번 매도는 시장 상황을 잘 반영한 결정이었다.", requiredMode = RequiredMode.NOT_REQUIRED)
     private String content;
 
     @Schema(description = "투자원칙 체크 목록", requiredMode = RequiredMode.NOT_REQUIRED)

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/repository/RetrospectionRepositoryImpl.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/repository/RetrospectionRepositoryImpl.java
@@ -23,19 +23,18 @@ public class RetrospectionRepositoryImpl implements RetrospectionRepository {
     @Override
     public Retrospection getById(Long id) {
         return jpaRetrospectionRepository
-                .findById(id)
-                .orElseThrow(
-                        () -> new ApplicationException(CodeEnum.FRS_003, "회고를 찾을 수 없습니다: " + id));
+            .findById(id)
+            .orElseThrow(
+                () -> new ApplicationException(CodeEnum.FRS_003, "회고를 찾을 수 없습니다: " + id));
     }
 
     @Override
     public Retrospection findByIdAndUserId(Long id, Long userId) {
         return jpaRetrospectionRepository
-                .findByIdAndUserId(id, userId)
-                .orElseThrow(
-                        () ->
-                                new ApplicationException(
-                                        CodeEnum.FRS_003,
-                                        "유저(" + userId + ")에 해당하는 회고(" + id + ")를 찾을 수 없습니다: "));
+            .findByIdAndUserId(id, userId)
+            .orElseThrow(
+                () -> new ApplicationException(
+                    CodeEnum.FRS_003,
+                    "유저(" + userId + ")에 해당하는 회고(" + id + ")를 찾을 수 없습니다: "));
     }
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/service/RetrospectionService.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/service/RetrospectionService.java
@@ -38,14 +38,12 @@ public class RetrospectionService implements CreateRetrospectionUseCase, GetRetr
     @Transactional
     public Retrospection createRetrospection(CreateRetrospectionCommand command) {
         // 사용자 조회
-        User user =
-                userRepository
-                        .findById(command.getUserId())
-                        .orElseThrow(
-                                () ->
-                                        new ApplicationException(
-                                                CodeEnum.FRS_003,
-                                                "사용자를 찾을 수 없습니다: " + command.getUserId()));
+        User user = userRepository
+            .findById(command.getUserId())
+            .orElseThrow(
+                () -> new ApplicationException(
+                    CodeEnum.FRS_003,
+                    "사용자를 찾을 수 없습니다: " + command.getUserId()));
 
         // 엔티티 생성
         Retrospection retrospection = RetrospectionMapper.toEntity(command, user);
@@ -62,29 +60,26 @@ public class RetrospectionService implements CreateRetrospectionUseCase, GetRetr
     }
 
     private void savePrincipleChecks(
-            Retrospection retrospection,
-            List<PrincipleCheckCommand> principleCheckCommands,
-            Long userId) {
-        List<PrincipleCheck> principleChecks =
-                principleCheckCommands.stream()
-                        .map(
-                                command -> {
-                                    InvestmentPrinciple principle =
-                                            investmentPrincipleRepository
-                                                    .findByIdAndUserId(
-                                                            command.getPrincipleId(), userId)
-                                                    .orElseThrow(
-                                                            () ->
-                                                                    new ApplicationException(
-                                                                            CodeEnum.FRS_003,
-                                                                            "투자원칙을 찾을 수 없습니다: "
-                                                                                    + command
-                                                                                            .getPrincipleId()));
+        Retrospection retrospection,
+        List<PrincipleCheckCommand> principleCheckCommands,
+        Long userId) {
+        List<PrincipleCheck> principleChecks = principleCheckCommands.stream()
+            .map(
+                command -> {
+                    InvestmentPrinciple principle = investmentPrincipleRepository
+                        .findByIdAndUserId(
+                            command.getPrincipleId(), userId)
+                        .orElseThrow(
+                            () -> new ApplicationException(
+                                CodeEnum.FRS_003,
+                                "투자원칙을 찾을 수 없습니다: "
+                                    + command
+                                        .getPrincipleId()));
 
-                                    return PrincipleCheck.create(
-                                            retrospection, principle, command.getIsFollowed());
-                                })
-                        .toList();
+                    return PrincipleCheck.create(
+                        retrospection, principle, command.getIsFollowed());
+                })
+            .toList();
 
         principleCheckRepository.saveAll(principleChecks);
     }
@@ -92,12 +87,10 @@ public class RetrospectionService implements CreateRetrospectionUseCase, GetRetr
     @Override
     @Transactional(readOnly = true)
     public GetRetrospectionResponse getRetrospection(Long retrospectionId, Long userId) {
-        Retrospection retrospection =
-                retrospectionRepository.findByIdAndUserId(retrospectionId, userId);
-        List<PrincipleCheck> principleChecks =
-                principleCheckRepository.findByRetrospectionId(retrospectionId).stream()
-                        .filter(pc -> Boolean.TRUE.equals(pc.getIsFollowed()))
-                        .toList();
+        Retrospection retrospection = retrospectionRepository.findByIdAndUserId(retrospectionId, userId);
+        List<PrincipleCheck> principleChecks = principleCheckRepository.findByRetrospectionId(retrospectionId).stream()
+            .filter(pc -> Boolean.TRUE.equals(pc.getIsFollowed()))
+            .toList();
 
         return RetrospectionMapper.toGetResponse(retrospection, principleChecks);
     }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/sample/controller/SampleStockController.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/sample/controller/SampleStockController.java
@@ -17,42 +17,31 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @Tag(name = "Sample Stock", description = "샘플 주식 관리 API")
 public class SampleStockController {
 
-    @Operation(
-            summary = "주식 매매 기록 생성",
-            description = "새로운 주식 매매 기록을 생성합니다.",
-            security = @SecurityRequirement(name = SwaggerConfig.SECURITY_SCHEME_NAME) // JWT
-            // 인증
-            // 필요한
-            // 엔드포인트인
-            // 경우
-            // 추가
-            )
+    @Operation(summary = "주식 매매 기록 생성", description = "새로운 주식 매매 기록을 생성합니다.", security = @SecurityRequirement(name = SwaggerConfig.SECURITY_SCHEME_NAME) // JWT
+    // 인증
+    // 필요한
+    // 엔드포인트인
+    // 경우
+    // 추가
+    )
     @PostMapping
     public ResponseEntity<String> createStock(@RequestBody SampleStockCreateRequest request) {
         // 샘플 로직
         return ResponseEntity.ok("주식 매매 기록이 생성되었습니다: " + request.getStockName());
     }
 
-    @Operation(
-            summary = "주식 목록 조회",
-            description = "사용자의 주식 매매 기록 목록을 조회합니다.",
-            security = @SecurityRequirement(name = SwaggerConfig.SECURITY_SCHEME_NAME))
+    @Operation(summary = "주식 목록 조회", description = "사용자의 주식 매매 기록 목록을 조회합니다.", security = @SecurityRequirement(name = SwaggerConfig.SECURITY_SCHEME_NAME))
     @GetMapping
     public ResponseEntity<String> getStocks(
-            @Parameter(description = "페이지 번호", example = "0") @RequestParam(defaultValue = "0")
-                    int page,
-            @Parameter(description = "페이지 크기", example = "10") @RequestParam(defaultValue = "10")
-                    int size) {
+        @Parameter(description = "페이지 번호", example = "0") @RequestParam(defaultValue = "0") int page,
+        @Parameter(description = "페이지 크기", example = "10") @RequestParam(defaultValue = "10") int size) {
         return ResponseEntity.ok("주식 목록 조회 완료 (page=" + page + ", size=" + size + ")");
     }
 
-    @Operation(
-            summary = "주식 상세 조회",
-            description = "특정 주식 매매 기록의 상세 정보를 조회합니다.",
-            security = @SecurityRequirement(name = SwaggerConfig.SECURITY_SCHEME_NAME))
+    @Operation(summary = "주식 상세 조회", description = "특정 주식 매매 기록의 상세 정보를 조회합니다.", security = @SecurityRequirement(name = SwaggerConfig.SECURITY_SCHEME_NAME))
     @GetMapping("/{stockId}")
     public ResponseEntity<String> getStock(
-            @Parameter(description = "주식 기록 ID", example = "1") @PathVariable Long stockId) {
+        @Parameter(description = "주식 기록 ID", example = "1") @PathVariable Long stockId) {
         return ResponseEntity.ok("주식 ID " + stockId + " 상세 정보 조회");
     }
 

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/sample/dto/SampleStockCreateRequest.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/sample/dto/SampleStockCreateRequest.java
@@ -21,16 +21,10 @@ public class SampleStockCreateRequest {
     @Schema(description = "매매수량", example = "10", requiredMode = Schema.RequiredMode.REQUIRED)
     private Integer quantity;
 
-    @Schema(
-            description = "매매타입 (BUY/SELL)",
-            example = "BUY",
-            allowableValues = {"BUY", "SELL"},
-            requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(description = "매매타입 (BUY/SELL)", example = "BUY", allowableValues = {"BUY",
+        "SELL"}, requiredMode = Schema.RequiredMode.REQUIRED)
     private String tradeType;
 
-    @Schema(
-            description = "메모",
-            example = "기술적 분석에 따른 매수",
-            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @Schema(description = "메모", example = "기술적 분석에 따른 매수", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String memo;
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/stock/controller/ChartQueryController.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/stock/controller/ChartQueryController.java
@@ -28,29 +28,25 @@ public class ChartQueryController {
     @Tag(name = "Stock Chart", description = "주식 조회")
     @GetMapping("/stock/charts/{market}/{code}")
     public HttpApiResponse<ChartResponse.ChartData> getStockCharts(
-            @PathVariable String market,
-            @PathVariable String code,
-            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
-            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
-            @RequestParam(defaultValue = "DAILY") StockInterval interval) {
-        StockChartData stockChartData =
-                chartQueryUseCase.getStockChart(market, code, startDate, endDate, interval);
+        @PathVariable String market,
+        @PathVariable String code,
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
+        @RequestParam(defaultValue = "DAILY") StockInterval interval) {
+        StockChartData stockChartData = chartQueryUseCase.getStockChart(market, code, startDate, endDate, interval);
 
-        List<ChartResponse.ChartItem> chartItems =
-                stockChartData.getChartData().stream()
-                        .map(
-                                item ->
-                                        new ChartResponse.ChartItem(
-                                                item.getDate(),
-                                                item.getOpen(),
-                                                item.getHigh(),
-                                                item.getLow(),
-                                                item.getClose(),
-                                                item.getVolume()))
-                        .collect(Collectors.toList());
+        List<ChartResponse.ChartItem> chartItems = stockChartData.getChartData().stream()
+            .map(
+                item -> new ChartResponse.ChartItem(
+                    item.getDate(),
+                    item.getOpen(),
+                    item.getHigh(),
+                    item.getLow(),
+                    item.getClose(),
+                    item.getVolume()))
+            .collect(Collectors.toList());
 
-        ChartResponse.ChartData chartData =
-                new ChartResponse.ChartData(stockChartData.getCurrency(), chartItems);
+        ChartResponse.ChartData chartData = new ChartResponse.ChartData(stockChartData.getCurrency(), chartItems);
 
         return HttpApiResponse.of(chartData);
     }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/stock/controller/StockSearchController.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/stock/controller/StockSearchController.java
@@ -29,11 +29,9 @@ public class StockSearchController {
     @Deprecated(since = "2025-09-20", forRemoval = true)
     @GetMapping("/stock/search")
     public HttpApiResponse<List<StockSearchResponse>> searchStock(
-            @Parameter(description = "검색 키워드 (종목명 또는 종목 코드)", required = true) @RequestParam
-                    String query) {
+        @Parameter(description = "검색 키워드 (종목명 또는 종목 코드)", required = true) @RequestParam String query) {
 
-        List<StockSearchResponse> mockData =
-                Arrays.asList(new StockSearchResponse(Market.NAS, "TSLA", "테슬라"));
+        List<StockSearchResponse> mockData = Arrays.asList(new StockSearchResponse(Market.NAS, "TSLA", "테슬라"));
 
         return HttpApiResponse.of(mockData);
     }
@@ -41,14 +39,11 @@ public class StockSearchController {
     @Operation(summary = "주식 검색 (페이지네이션)", description = "종목명 또는 종목 코드로 주식을 무한스크롤 방식으로 검색합니다.")
     @GetMapping("/stock/slice")
     public HttpApiResponse<SliceContent<StockSearchResponse>> searchStockSlice(
-            @Parameter(description = "검색 키워드 (종목명 또는 종목 코드)", required = true) @RequestParam
-                    String companyName,
-            @Parameter(description = "다음 페이지 커서 (첫 페이지는 null)") @RequestParam(required = false)
-                    String nextCursor,
-            @Parameter(description = "페이지 크기 (기본값: 10)") @RequestParam(defaultValue = "10")
-                    int size) {
-        SliceContent<StockSearchResponse> response =
-                stockQueryUseCase.findByCompanyNameSlice(nextCursor, companyName, size);
+        @Parameter(description = "검색 키워드 (종목명 또는 종목 코드)", required = true) @RequestParam String companyName,
+        @Parameter(description = "다음 페이지 커서 (첫 페이지는 null)") @RequestParam(required = false) String nextCursor,
+        @Parameter(description = "페이지 크기 (기본값: 10)") @RequestParam(defaultValue = "10") int size) {
+        SliceContent<StockSearchResponse> response = stockQueryUseCase.findByCompanyNameSlice(nextCursor, companyName,
+            size);
 
         return HttpApiResponse.of(response);
     }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/stock/port/out/HanStockFeignClient.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/stock/port/out/HanStockFeignClient.java
@@ -19,14 +19,14 @@ public interface HanStockFeignClient {
 
     @GetMapping("/uapi/overseas-price/v1/quotations/dailyprice")
     DailyPriceResponse getDailyPrice(
-            @RequestHeader("authorization") String authorization,
-            @RequestHeader("appkey") String appkey,
-            @RequestHeader("appsecret") String appsecret,
-            @RequestHeader("tr_id") String trId,
-            @RequestParam("AUTH") String auth,
-            @RequestParam("EXCD") String market,
-            @RequestParam("SYMB") String symbol,
-            @RequestParam("GUBN") String period,
-            @RequestParam("BYMD") String baseDate,
-            @RequestParam("MODP") String modifiedPrice);
+        @RequestHeader("authorization") String authorization,
+        @RequestHeader("appkey") String appkey,
+        @RequestHeader("appsecret") String appsecret,
+        @RequestHeader("tr_id") String trId,
+        @RequestParam("AUTH") String auth,
+        @RequestParam("EXCD") String market,
+        @RequestParam("SYMB") String symbol,
+        @RequestParam("GUBN") String period,
+        @RequestParam("BYMD") String baseDate,
+        @RequestParam("MODP") String modifiedPrice);
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/stock/port/out/StockPortImpl.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/stock/port/out/StockPortImpl.java
@@ -22,8 +22,7 @@ public class StockPortImpl implements StockPort {
     private final TokenManager tokenManager;
 
     private static final String APP_KEY = "PSOA5a8EUEzQnsbb0Stieigj9n8jUUBiwJ0A";
-    private static final String APP_SECRET =
-            "wS6taqks0+FJmyHxrFouol6EOLJhSMhyLrvsUHcqlvHxEVxa/TYXqFqD0M/eOMWGmnPPB+X/fuqr8LnJJK/ZKMlcDOxVWo5BU85hom/PgpP0H4p5pYJjESLXAuRkdrrnp/UtapmJhOVOYQrkXqz2TkqCkYGW2zwgwYXPBGLisyHWWSRI8C0=";
+    private static final String APP_SECRET = "wS6taqks0+FJmyHxrFouol6EOLJhSMhyLrvsUHcqlvHxEVxa/TYXqFqD0M/eOMWGmnPPB+X/fuqr8LnJJK/ZKMlcDOxVWo5BU85hom/PgpP0H4p5pYJjESLXAuRkdrrnp/UtapmJhOVOYQrkXqz2TkqCkYGW2zwgwYXPBGLisyHWWSRI8C0=";
     private static final String TR_ID = "HHDFS76240000";
 
     public StockPortImpl(HanStockFeignClient hanStockFeignClient, TokenManager tokenManager) {
@@ -38,7 +37,7 @@ public class StockPortImpl implements StockPort {
 
     @Override
     public StockChartData getChartData(
-            String market, String symbol, LocalDate endDate, StockInterval interval) {
+        String market, String symbol, LocalDate endDate, StockInterval interval) {
         String formattedEndDate = endDate.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
 
         // 첫 번째 시도
@@ -55,7 +54,7 @@ public class StockPortImpl implements StockPort {
                 } catch (Exception retryException) {
                     log.error("Retry failed: {}", retryException.getMessage());
                     throw new RuntimeException(
-                            "API call failed after token refresh", retryException);
+                        "API call failed after token refresh", retryException);
                 }
             } else {
                 log.error("Non-4xx error occurred: {}", e.getMessage());
@@ -65,22 +64,21 @@ public class StockPortImpl implements StockPort {
     }
 
     private StockChartData callDailyPriceApi(
-            String market, String symbol, String formattedEndDate, StockInterval interval) {
+        String market, String symbol, String formattedEndDate, StockInterval interval) {
         String token = tokenManager.getValidToken();
         String authorization = "Bearer " + token;
 
-        DailyPriceResponse response =
-                hanStockFeignClient.getDailyPrice(
-                        authorization,
-                        APP_KEY,
-                        APP_SECRET,
-                        TR_ID,
-                        "",
-                        market,
-                        symbol,
-                        interval.getCode(),
-                        formattedEndDate,
-                        "1");
+        DailyPriceResponse response = hanStockFeignClient.getDailyPrice(
+            authorization,
+            APP_KEY,
+            APP_SECRET,
+            TR_ID,
+            "",
+            market,
+            symbol,
+            interval.getCode(),
+            formattedEndDate,
+            "1");
 
         return DailyPriceResponse.toStockChartData(response, market);
     }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/stock/port/out/dto/DailyPriceResponse.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/stock/port/out/dto/DailyPriceResponse.java
@@ -37,10 +37,9 @@ public class DailyPriceResponse {
     public static StockChartData toStockChartData(DailyPriceResponse response, String market) {
         String currency = getCurrencyByMarket(market);
 
-        List<StockChartItem> chartItems =
-                response.getOutput2().stream()
-                        .map(DailyPriceResponse::toStockChartItem)
-                        .collect(Collectors.toList());
+        List<StockChartItem> chartItems = response.getOutput2().stream()
+            .map(DailyPriceResponse::toStockChartItem)
+            .collect(Collectors.toList());
 
         return new StockChartData(currency, chartItems);
     }
@@ -60,19 +59,19 @@ public class DailyPriceResponse {
 
     private static String getCurrencyByMarket(String market) {
         switch (market.toUpperCase()) {
-            case "NAS":
-            case "NYSE":
-            case "AMEX":
+            case "NAS" :
+            case "NYSE" :
+            case "AMEX" :
                 return "USD";
-            case "TSE":
+            case "TSE" :
                 return "JPY";
-            case "LSE":
+            case "LSE" :
                 return "GBP";
-            case "FRA":
+            case "FRA" :
                 return "EUR";
-            case "HKG":
+            case "HKG" :
                 return "HKD";
-            default:
+            default :
                 return "USD";
         }
     }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/stock/repository/JpaStockRepository.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/stock/repository/JpaStockRepository.java
@@ -17,8 +17,7 @@ public interface JpaStockRepository extends CrudRepository<Stock, Long> {
     @Query("SELECT s FROM Stock s WHERE s.companyName LIKE %:companyName% ORDER BY s.id DESC")
     List<Stock> findByCompanyNameLikeOrderByIdDesc(String companyName, Pageable pageable);
 
-    @Query(
-            "SELECT s FROM Stock s WHERE s.companyName LIKE %:companyName% AND s.id < :cursor ORDER BY s.id DESC")
+    @Query("SELECT s FROM Stock s WHERE s.companyName LIKE %:companyName% AND s.id < :cursor ORDER BY s.id DESC")
     List<Stock> findByCompanyNameLikeOrderByIdDesc(
-            String companyName, Integer cursor, Pageable pageable);
+        String companyName, Integer cursor, Pageable pageable);
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/stock/repository/StockRepositoryImpl.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/stock/repository/StockRepositoryImpl.java
@@ -24,17 +24,15 @@ public class StockRepositoryImpl implements StockRepository {
 
     @Override
     public SliceContent<Stock> findByCompanyNameSlice(
-            String nextCursor, String companyName, int size) {
+        String nextCursor, String companyName, int size) {
         List<Stock> content;
 
         if (nextCursor == null) {
-            content =
-                    jpaStockRepository.findByCompanyNameLikeOrderByIdDesc(
-                            companyName, PageRequest.of(0, size));
+            content = jpaStockRepository.findByCompanyNameLikeOrderByIdDesc(
+                companyName, PageRequest.of(0, size));
         } else {
-            content =
-                    jpaStockRepository.findByCompanyNameLikeOrderByIdDesc(
-                            companyName, Integer.parseInt(nextCursor), PageRequest.of(0, size));
+            content = jpaStockRepository.findByCompanyNameLikeOrderByIdDesc(
+                companyName, Integer.parseInt(nextCursor), PageRequest.of(0, size));
         }
 
         String id = content.isEmpty() ? null : content.get(content.size() - 1).getId().toString();

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/stock/service/TokenManager.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/stock/service/TokenManager.java
@@ -22,8 +22,7 @@ public class TokenManager {
     private final HanStockFeignClient hanStockFeignClient;
     private static final String TOKEN_FILE_PATH = "stock_api_token.txt";
     private static final String APP_KEY = "PSOA5a8EUEzQnsbb0Stieigj9n8jUUBiwJ0A";
-    private static final String APP_SECRET =
-            "wS6taqks0+FJmyHxrFouol6EOLJhSMhyLrvsUHcqlvHxEVxa/TYXqFqD0M/eOMWGmnPPB+X/fuqr8LnJJK/ZKMlcDOxVWo5BU85hom/PgpP0H4p5pYJjESLXAuRkdrrnp/UtapmJhOVOYQrkXqz2TkqCkYGW2zwgwYXPBGLisyHWWSRI8C0=";
+    private static final String APP_SECRET = "wS6taqks0+FJmyHxrFouol6EOLJhSMhyLrvsUHcqlvHxEVxa/TYXqFqD0M/eOMWGmnPPB+X/fuqr8LnJJK/ZKMlcDOxVWo5BU85hom/PgpP0H4p5pYJjESLXAuRkdrrnp/UtapmJhOVOYQrkXqz2TkqCkYGW2zwgwYXPBGLisyHWWSRI8C0=";
 
     public TokenManager(HanStockFeignClient hanStockFeignClient) {
         this.hanStockFeignClient = hanStockFeignClient;
@@ -89,8 +88,7 @@ public class TokenManager {
 
             // 토큰이 24시간 이내인지 확인
             try {
-                LocalDateTime tokenTime =
-                        LocalDateTime.parse(timestamp, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+                LocalDateTime tokenTime = LocalDateTime.parse(timestamp, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
                 if (tokenTime.plusHours(23).isAfter(LocalDateTime.now())) {
                     return token;
                 }
@@ -103,8 +101,7 @@ public class TokenManager {
     }
 
     private void saveTokenToFile(String token) throws IOException {
-        String content =
-                LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME) + "\n" + token;
+        String content = LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME) + "\n" + token;
         Path path = Paths.get(TOKEN_FILE_PATH);
         Files.writeString(path, content);
         log.info("Token saved to file: {}", TOKEN_FILE_PATH);

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/user/controller/AuthController.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/user/controller/AuthController.java
@@ -21,17 +21,15 @@ public class AuthController {
 
     @PostMapping("/social/login")
     public ResponseEntity<SocialLoginResponse> socialLogin(
-            @RequestBody SocialLoginRequest request) {
+        @RequestBody SocialLoginRequest request) {
         try {
-            AuthResult authResult =
-                    authService.socialLogin(
-                            request.getProvider(),
-                            request.getAuthCode(),
-                            request.getEmail(),
-                            request.getNickname());
+            AuthResult authResult = authService.socialLogin(
+                request.getProvider(),
+                request.getAuthCode(),
+                request.getEmail(),
+                request.getNickname());
 
-            SocialLoginResponse response =
-                    SocialLoginResponse.from(authResult.getUser(), authResult.isNewUser());
+            SocialLoginResponse response = SocialLoginResponse.from(authResult.getUser(), authResult.isNewUser());
             return ResponseEntity.ok(response);
 
         } catch (Exception e) {

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/user/dto/SocialLoginResponse.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/user/dto/SocialLoginResponse.java
@@ -18,10 +18,10 @@ public class SocialLoginResponse {
 
     public static SocialLoginResponse from(User user, boolean isNewUser) {
         return new SocialLoginResponse(
-                user.getId(),
-                user.getNickname(),
-                user.getEmail(),
-                user.getProfileImageUrl(),
-                isNewUser);
+            user.getId(),
+            user.getNickname(),
+            user.getEmail(),
+            user.getProfileImageUrl(),
+            isNewUser);
     }
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/user/port/out/oauth/client/AppleOAuthClient.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/user/port/out/oauth/client/AppleOAuthClient.java
@@ -52,22 +52,22 @@ public class AppleOAuthClient implements OAuthClient {
         params.add("redirect_uri", appleProperties.getRedirectUri());
 
         return restClient
-                .post()
-                .uri(APPLE_AUTH_URL + TOKEN_ENDPOINT)
-                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .body(params)
-                .retrieve()
-                .body(OAuthTokenResponse.class);
+            .post()
+            .uri(APPLE_AUTH_URL + TOKEN_ENDPOINT)
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+            .body(params)
+            .retrieve()
+            .body(OAuthTokenResponse.class);
     }
 
     @Override
     @Cacheable(value = "oidcPublicKeys", key = "'apple'")
     public OIDCPublicKeyList getPublicKeys() {
         return restClient
-                .get()
-                .uri(APPLE_AUTH_URL + KEYS_ENDPOINT)
-                .retrieve()
-                .body(OIDCPublicKeyList.class);
+            .get()
+            .uri(APPLE_AUTH_URL + KEYS_ENDPOINT)
+            .retrieve()
+            .body(OIDCPublicKeyList.class);
     }
 
     @Override
@@ -81,31 +81,30 @@ public class AppleOAuthClient implements OAuthClient {
         params.add("token_type_hint", "refresh_token");
 
         restClient
-                .post()
-                .uri(APPLE_AUTH_URL + REVOKE_ENDPOINT)
-                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .body(params)
-                .retrieve()
-                .toBodilessEntity();
+            .post()
+            .uri(APPLE_AUTH_URL + REVOKE_ENDPOINT)
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+            .body(params)
+            .retrieve()
+            .toBodilessEntity();
     }
 
     private String generateClientSecret() {
         try {
             LocalDateTime now = LocalDateTime.now();
             Date issuedAt = Date.from(now.atZone(ZoneId.systemDefault()).toInstant());
-            Date expiration =
-                    Date.from(now.plusMinutes(5).atZone(ZoneId.systemDefault()).toInstant());
+            Date expiration = Date.from(now.plusMinutes(5).atZone(ZoneId.systemDefault()).toInstant());
 
             return Jwts.builder()
-                    .setHeaderParam("kid", appleProperties.getKeyId())
-                    .setHeaderParam("alg", "ES256")
-                    .setIssuer(appleProperties.getTeamId())
-                    .setIssuedAt(issuedAt)
-                    .setExpiration(expiration)
-                    .setAudience(appleProperties.getAud())
-                    .setSubject(appleProperties.getClientId())
-                    .signWith(getPrivateKey(), SignatureAlgorithm.ES256)
-                    .compact();
+                .setHeaderParam("kid", appleProperties.getKeyId())
+                .setHeaderParam("alg", "ES256")
+                .setIssuer(appleProperties.getTeamId())
+                .setIssuedAt(issuedAt)
+                .setExpiration(expiration)
+                .setAudience(appleProperties.getAud())
+                .setSubject(appleProperties.getClientId())
+                .signWith(getPrivateKey(), SignatureAlgorithm.ES256)
+                .compact();
         } catch (Exception e) {
             log.error("Failed to generate Apple client secret", e);
             throw new RuntimeException("Failed to generate Apple client secret", e);
@@ -113,8 +112,7 @@ public class AppleOAuthClient implements OAuthClient {
     }
 
     private PrivateKey getPrivateKey() throws IOException {
-        String privateKeyPEM =
-                new String(Base64.getDecoder().decode(appleProperties.getPrivateKey()));
+        String privateKeyPEM = new String(Base64.getDecoder().decode(appleProperties.getPrivateKey()));
 
         try (PEMParser pemParser = new PEMParser(new StringReader(privateKeyPEM))) {
             PrivateKeyInfo privateKeyInfo = (PrivateKeyInfo) pemParser.readObject();

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/user/repository/AppleAuthTokenRepository.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/user/repository/AppleAuthTokenRepository.java
@@ -4,4 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.ogd.stockdiary.domain.user.entity.AppleAuthToken;
 
-public interface AppleAuthTokenRepository extends JpaRepository<AppleAuthToken, Long> {}
+public interface AppleAuthTokenRepository extends JpaRepository<AppleAuthToken, Long> {
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/user/repository/UserRepository.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/user/repository/UserRepository.java
@@ -11,10 +11,9 @@ import com.ogd.stockdiary.domain.user.entity.User;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    @Query(
-            "SELECT u FROM User u WHERE u.oAuthProviderInfo.oauthProvider = :provider AND u.oAuthProviderInfo.subject = :subject")
+    @Query("SELECT u FROM User u WHERE u.oAuthProviderInfo.oauthProvider = :provider AND u.oAuthProviderInfo.subject = :subject")
     Optional<User> findByOAuthProviderAndSubject(
-            @Param("provider") OAuthProvider provider, @Param("subject") String subject);
+        @Param("provider") OAuthProvider provider, @Param("subject") String subject);
 
     Optional<User> findByEmail(String email);
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/common/httpresponse/CodeEnum.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/common/httpresponse/CodeEnum.java
@@ -1,12 +1,7 @@
 package com.ogd.stockdiary.common.httpresponse;
 
 public enum CodeEnum {
-    RS_001("실행 성공"),
-    FRS_001("실행 실패"),
-    FRS_002("권한 없음"),
-    FRS_003("데이터 없음"),
-    FRS_004("서버 오류"),
-    FRS_005("잘못된 요청"),
+    RS_001("실행 성공"), FRS_001("실행 실패"), FRS_002("권한 없음"), FRS_003("데이터 없음"), FRS_004("서버 오류"), FRS_005("잘못된 요청"),
     ;
 
     private final String description;

--- a/stock-diary/src/main/java/com/ogd/stockdiary/common/httpresponse/HttpApiResponse.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/common/httpresponse/HttpApiResponse.java
@@ -27,7 +27,7 @@ public class HttpApiResponse<T> {
     }
 
     public static HttpApiResponse fromExceptionMessage(
-            String message, CodeEnum code, Map<String, Object> data) {
+        String message, CodeEnum code, Map<String, Object> data) {
         return HttpApiResponse.builder().code(CodeEnum.FRS_001).data(data).message(message).build();
     }
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/common/httpresponse/SliceContent.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/common/httpresponse/SliceContent.java
@@ -2,4 +2,5 @@ package com.ogd.stockdiary.common.httpresponse;
 
 import java.util.List;
 
-public record SliceContent<T>(List<T> content, String nextCursor) {}
+public record SliceContent<T>(List<T> content, String nextCursor) {
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/analysis/application/AnalysisController.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/analysis/application/AnalysisController.java
@@ -27,9 +27,9 @@ public class AnalysisController {
 
     @GetMapping(value = "v1")
     public ResponseEntity<HttpApiResponse<AnalysisResponse>> analyze(
-            @RequestParam String market,
-            @RequestParam String symbol,
-            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime time) {
+        @RequestParam String market,
+        @RequestParam String symbol,
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime time) {
 
         ChatResponse chatResponse = analysisService.analyze(market, symbol, time);
 
@@ -42,18 +42,16 @@ public class AnalysisController {
 
     @GetMapping(value = "v2/{modelName}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public Flux<AssistantMessage> analyzeSteamData(
-            @PathVariable String modelName,
-            @RequestParam String market,
-            @RequestParam String symbol,
-            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime time) {
+        @PathVariable String modelName,
+        @RequestParam String market,
+        @RequestParam String symbol,
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime time) {
 
-        Flux<ChatResponse> chatResponse =
-                analysisService.analyzeStreamData(modelName, market, symbol, time);
+        Flux<ChatResponse> chatResponse = analysisService.analyzeStreamData(modelName, market, symbol, time);
 
-        Flux<AssistantMessage> messageFlux =
-                chatResponse
-                        .map(response -> response.getResult())
-                        .map(generation -> generation.getOutput());
+        Flux<AssistantMessage> messageFlux = chatResponse
+            .map(response -> response.getResult())
+            .map(generation -> generation.getOutput());
 
         return messageFlux;
     }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/analysis/application/AnalysisService.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/analysis/application/AnalysisService.java
@@ -27,8 +27,7 @@ public class AnalysisService {
     private final ChatModel chatModel;
 
     public ChatResponse analyze(String market, String symbol, LocalDateTime time) {
-        String userText =
-                """
+        String userText = """
             Today market is {market} and symbol is {symbol}.
             Time is {time}.
             You should reply to the user's request.
@@ -36,16 +35,14 @@ public class AnalysisService {
 
         PromptTemplate promptTemplate = new PromptTemplate(userText);
 
-        Message userMessage =
-                promptTemplate.createMessage(
-                        Map.of("market", market, "symbol", symbol, "time", time.toString()));
+        Message userMessage = promptTemplate.createMessage(
+            Map.of("market", market, "symbol", symbol, "time", time.toString()));
 
         Message systemMessage = new SystemMessage(promptLoader.getPrompt());
 
         String modelName = "gpt-4.1-nano";
 
-        OpenAiChatOptions options =
-                OpenAiChatOptions.builder().model(modelName).maxTokens(250).build();
+        OpenAiChatOptions options = OpenAiChatOptions.builder().model(modelName).maxTokens(250).build();
 
         Prompt prompt = new Prompt(List.of(systemMessage, userMessage), options);
 
@@ -55,24 +52,21 @@ public class AnalysisService {
     }
 
     public Flux<ChatResponse> analyzeStreamData(
-            String modelName, String market, String symbol, LocalDateTime time) {
-        String systemText =
-                """
+        String modelName, String market, String symbol, LocalDateTime time) {
+        String systemText = """
             Today market is {market} and symbol is {symbol}.
             Time is {time}.
             You should reply to the user's request.
             """;
-        Message systemMessage =
-                new SystemPromptTemplate(systemText)
-                        .createMessage(
-                                Map.of(
-                                        "market", market,
-                                        "symbol", symbol,
-                                        "time", time.toString()));
+        Message systemMessage = new SystemPromptTemplate(systemText)
+            .createMessage(
+                Map.of(
+                    "market", market,
+                    "symbol", symbol,
+                    "time", time.toString()));
         Message userMessage = new UserMessage(promptLoader.getPrompt());
 
-        OpenAiChatOptions options =
-                OpenAiChatOptions.builder().model(modelName).maxTokens(250).build();
+        OpenAiChatOptions options = OpenAiChatOptions.builder().model(modelName).maxTokens(250).build();
 
         Prompt prompt = new Prompt(List.of(systemMessage, userMessage), options);
 

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/analysis/dto/AnalysisResponse.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/analysis/dto/AnalysisResponse.java
@@ -1,3 +1,4 @@
 package com.ogd.stockdiary.domain.analysis.dto;
 
-public record AnalysisResponse(String text) {}
+public record AnalysisResponse(String text) {
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/investmentprinciple/dto/CreatePrincipleCommand.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/investmentprinciple/dto/CreatePrincipleCommand.java
@@ -8,5 +8,7 @@ import lombok.RequiredArgsConstructor;
 public class CreatePrincipleCommand {
 
     private final Long userId;
+    private final Long groupId;
     private final String principle;
+    private final Integer displayOrder;
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/investmentprinciple/dto/ReorderPrinciplesCommand.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/investmentprinciple/dto/ReorderPrinciplesCommand.java
@@ -1,0 +1,21 @@
+package com.ogd.stockdiary.domain.investmentprinciple.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ReorderPrinciplesCommand {
+
+    private Long userId;
+    private List<PrincipleOrder> principleOrders;
+
+    @Getter
+    @AllArgsConstructor
+    public static class PrincipleOrder {
+        private Long principleId;
+        private Integer displayOrder;
+    }
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/investmentprinciple/entity/InvestmentPrinciple.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/investmentprinciple/entity/InvestmentPrinciple.java
@@ -14,6 +14,7 @@ import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 
+import com.ogd.stockdiary.domain.principlegroup.entity.PrincipleGroup;
 import com.ogd.stockdiary.domain.user.entity.User;
 
 import lombok.Getter;
@@ -25,6 +26,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class InvestmentPrinciple {
 
+    public static final int MAX_PRINCIPLES_PER_GROUP = 5;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -33,7 +36,14 @@ public class InvestmentPrinciple {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id")
+    private PrincipleGroup principleGroup;
+
     private String principle;
+
+    @Column(name = "display_order")
+    private Integer displayOrder;
 
     @Column(updatable = false)
     private LocalDateTime createdAt;
@@ -58,7 +68,21 @@ public class InvestmentPrinciple {
         return investmentPrinciple;
     }
 
+    public static InvestmentPrinciple create(
+        User user, PrincipleGroup principleGroup, String principle, Integer displayOrder) {
+        InvestmentPrinciple investmentPrinciple = new InvestmentPrinciple();
+        investmentPrinciple.user = user;
+        investmentPrinciple.principleGroup = principleGroup;
+        investmentPrinciple.principle = principle;
+        investmentPrinciple.displayOrder = displayOrder;
+        return investmentPrinciple;
+    }
+
     public void updatePrinciple(String principle) {
         this.principle = principle;
+    }
+
+    public void updateDisplayOrder(Integer displayOrder) {
+        this.displayOrder = displayOrder;
     }
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/investmentprinciple/port/out/InvestmentPrincipleRepository.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/investmentprinciple/port/out/InvestmentPrincipleRepository.java
@@ -18,4 +18,8 @@ public interface InvestmentPrincipleRepository {
     void deleteByIdAndUserId(Long principleId, Long userId);
 
     void deleteAllByIdInAndUserId(List<Long> principleIds, Long userId);
+
+    List<InvestmentPrinciple> findByPrincipleGroupId(Long groupId);
+
+    void deleteByPrincipleGroupId(Long groupId);
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/investmentprinciple/service/InvestmentPrincipleService.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/investmentprinciple/service/InvestmentPrincipleService.java
@@ -13,10 +13,13 @@ import com.ogd.stockdiary.domain.investmentprinciple.dto.BatchProcessCommand;
 import com.ogd.stockdiary.domain.investmentprinciple.dto.BatchProcessResult;
 import com.ogd.stockdiary.domain.investmentprinciple.dto.CreateMultiplePrinciplesCommand;
 import com.ogd.stockdiary.domain.investmentprinciple.dto.CreatePrincipleCommand;
+import com.ogd.stockdiary.domain.investmentprinciple.dto.ReorderPrinciplesCommand;
 import com.ogd.stockdiary.domain.investmentprinciple.dto.UpdatePrincipleCommand;
 import com.ogd.stockdiary.domain.investmentprinciple.entity.InvestmentPrinciple;
 import com.ogd.stockdiary.domain.investmentprinciple.port.out.InvestmentPrincipleRepository;
 import com.ogd.stockdiary.domain.investmentprinciple.usecase.InvestmentPrincipleUseCase;
+import com.ogd.stockdiary.domain.principlegroup.entity.PrincipleGroup;
+import com.ogd.stockdiary.domain.principlegroup.port.out.PrincipleGroupRepository;
 import com.ogd.stockdiary.domain.user.entity.User;
 import com.ogd.stockdiary.exception.ApplicationException;
 
@@ -28,6 +31,7 @@ import lombok.RequiredArgsConstructor;
 public class InvestmentPrincipleService implements InvestmentPrincipleUseCase {
 
     private final InvestmentPrincipleRepository investmentPrincipleRepository;
+    private final PrincipleGroupRepository principleGroupRepository;
     private final UserRepository userRepository;
 
     @Override
@@ -38,49 +42,70 @@ public class InvestmentPrincipleService implements InvestmentPrincipleUseCase {
 
     @Override
     public InvestmentPrinciple createPrinciple(CreatePrincipleCommand command) {
-        User user =
-                userRepository
-                        .findById(command.getUserId())
-                        .orElseThrow(
-                                () ->
-                                        new ApplicationException(
-                                                CodeEnum.FRS_003,
-                                                "사용자를 찾을 수 없습니다: " + command.getUserId()));
+        User user = userRepository
+            .findById(command.getUserId())
+            .orElseThrow(
+                () -> new ApplicationException(
+                    CodeEnum.FRS_003,
+                    "사용자를 찾을 수 없습니다: " + command.getUserId()));
 
-        InvestmentPrinciple principle = InvestmentPrinciple.create(user, command.getPrinciple());
+        InvestmentPrinciple principle;
+        if (command.getGroupId() != null) {
+            // 그룹이 지정된 경우
+            PrincipleGroup principleGroup = principleGroupRepository
+                .findByIdAndUserId(command.getGroupId(), command.getUserId())
+                .orElseThrow(
+                    () -> new ApplicationException(
+                        CodeEnum.FRS_003,
+                        "투자원칙 그룹을 찾을 수 없습니다: " + command.getGroupId()));
+
+            // 그룹에 속한 원칙 개수 확인
+            List<InvestmentPrinciple> existingPrinciples = investmentPrincipleRepository
+                .findByPrincipleGroupId(command.getGroupId());
+            if (existingPrinciples.size() >= InvestmentPrinciple.MAX_PRINCIPLES_PER_GROUP) {
+                throw new ApplicationException(
+                    CodeEnum.FRS_005,
+                    "그룹당 최대 " + InvestmentPrinciple.MAX_PRINCIPLES_PER_GROUP + "개의 투자원칙만 추가할 수 있습니다");
+            }
+
+            principle = InvestmentPrinciple.create(
+                user,
+                principleGroup,
+                command.getPrinciple(),
+                command.getDisplayOrder());
+        } else {
+            // 그룹이 없는 경우
+            principle = InvestmentPrinciple.create(user, command.getPrinciple());
+        }
+
         return investmentPrincipleRepository.save(principle);
     }
 
     @Override
     public List<InvestmentPrinciple> createMultiplePrinciples(
-            CreateMultiplePrinciplesCommand command) {
-        User user =
-                userRepository
-                        .findById(command.getUserId())
-                        .orElseThrow(
-                                () ->
-                                        new ApplicationException(
-                                                CodeEnum.FRS_003,
-                                                "사용자를 찾을 수 없습니다: " + command.getUserId()));
+        CreateMultiplePrinciplesCommand command) {
+        User user = userRepository
+            .findById(command.getUserId())
+            .orElseThrow(
+                () -> new ApplicationException(
+                    CodeEnum.FRS_003,
+                    "사용자를 찾을 수 없습니다: " + command.getUserId()));
 
-        List<InvestmentPrinciple> principles =
-                command.getPrinciples().stream()
-                        .map(principleText -> InvestmentPrinciple.create(user, principleText))
-                        .collect(Collectors.toList());
+        List<InvestmentPrinciple> principles = command.getPrinciples().stream()
+            .map(principleText -> InvestmentPrinciple.create(user, principleText))
+            .collect(Collectors.toList());
 
         return investmentPrincipleRepository.saveAll(principles);
     }
 
     @Override
     public InvestmentPrinciple updatePrinciple(UpdatePrincipleCommand command) {
-        InvestmentPrinciple principle =
-                investmentPrincipleRepository
-                        .findByIdAndUserId(command.getPrincipleId(), command.getUserId())
-                        .orElseThrow(
-                                () ->
-                                        new ApplicationException(
-                                                CodeEnum.FRS_003,
-                                                "투자원칙을 찾을 수 없습니다: " + command.getPrincipleId()));
+        InvestmentPrinciple principle = investmentPrincipleRepository
+            .findByIdAndUserId(command.getPrincipleId(), command.getUserId())
+            .orElseThrow(
+                () -> new ApplicationException(
+                    CodeEnum.FRS_003,
+                    "투자원칙을 찾을 수 없습니다: " + command.getPrincipleId()));
 
         principle.updatePrinciple(command.getPrinciple());
         return principle;
@@ -101,20 +126,19 @@ public class InvestmentPrincipleService implements InvestmentPrincipleUseCase {
         List<Long> deletedPrincipleIds = new ArrayList<>();
 
         // 생성
+        // Note: 현재 BatchProcess는 그룹 없이 원칙만 생성하므로 그룹당 5개 제한 검증 불필요
+        // 추후 그룹 정보가 추가되면 검증 로직 추가 필요
         if (command.getCreatePrinciples() != null && !command.getCreatePrinciples().isEmpty()) {
-            User user =
-                    userRepository
-                            .findById(command.getUserId())
-                            .orElseThrow(
-                                    () ->
-                                            new ApplicationException(
-                                                    CodeEnum.FRS_003,
-                                                    "사용자를 찾을 수 없습니다: " + command.getUserId()));
+            User user = userRepository
+                .findById(command.getUserId())
+                .orElseThrow(
+                    () -> new ApplicationException(
+                        CodeEnum.FRS_003,
+                        "사용자를 찾을 수 없습니다: " + command.getUserId()));
 
-            List<InvestmentPrinciple> principles =
-                    command.getCreatePrinciples().stream()
-                            .map(principleText -> InvestmentPrinciple.create(user, principleText))
-                            .collect(Collectors.toList());
+            List<InvestmentPrinciple> principles = command.getCreatePrinciples().stream()
+                .map(principleText -> InvestmentPrinciple.create(user, principleText))
+                .collect(Collectors.toList());
             createdPrinciples = investmentPrincipleRepository.saveAll(principles);
         }
 
@@ -129,10 +153,25 @@ public class InvestmentPrincipleService implements InvestmentPrincipleUseCase {
         // 삭제
         if (command.getDeletePrincipleIds() != null && !command.getDeletePrincipleIds().isEmpty()) {
             investmentPrincipleRepository.deleteAllByIdInAndUserId(
-                    command.getDeletePrincipleIds(), command.getUserId());
+                command.getDeletePrincipleIds(), command.getUserId());
             deletedPrincipleIds = command.getDeletePrincipleIds();
         }
 
         return new BatchProcessResult(createdPrinciples, updatedPrinciples, deletedPrincipleIds);
+    }
+
+    @Override
+    public void reorderPrinciples(ReorderPrinciplesCommand command) {
+        for (ReorderPrinciplesCommand.PrincipleOrder principleOrder : command.getPrincipleOrders()) {
+            InvestmentPrinciple principle = investmentPrincipleRepository
+                .findByIdAndUserId(principleOrder.getPrincipleId(), command.getUserId())
+                .orElseThrow(
+                    () -> new ApplicationException(
+                        CodeEnum.FRS_003,
+                        "투자원칙을 찾을 수 없습니다: "
+                            + principleOrder.getPrincipleId()));
+
+            principle.updateDisplayOrder(principleOrder.getDisplayOrder());
+        }
     }
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/investmentprinciple/usecase/InvestmentPrincipleUseCase.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/investmentprinciple/usecase/InvestmentPrincipleUseCase.java
@@ -6,6 +6,7 @@ import com.ogd.stockdiary.domain.investmentprinciple.dto.BatchProcessCommand;
 import com.ogd.stockdiary.domain.investmentprinciple.dto.BatchProcessResult;
 import com.ogd.stockdiary.domain.investmentprinciple.dto.CreateMultiplePrinciplesCommand;
 import com.ogd.stockdiary.domain.investmentprinciple.dto.CreatePrincipleCommand;
+import com.ogd.stockdiary.domain.investmentprinciple.dto.ReorderPrinciplesCommand;
 import com.ogd.stockdiary.domain.investmentprinciple.dto.UpdatePrincipleCommand;
 import com.ogd.stockdiary.domain.investmentprinciple.entity.InvestmentPrinciple;
 
@@ -22,4 +23,6 @@ public interface InvestmentPrincipleUseCase {
     void deletePrinciple(Long principleId, Long userId);
 
     BatchProcessResult batchProcessPrinciples(BatchProcessCommand command);
+
+    void reorderPrinciples(ReorderPrinciplesCommand command);
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlecheck/entity/PrincipleCheck.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlecheck/entity/PrincipleCheck.java
@@ -58,7 +58,7 @@ public class PrincipleCheck {
     }
 
     public static PrincipleCheck create(
-            Retrospection retrospection, InvestmentPrinciple principle, Boolean isFollowed) {
+        Retrospection retrospection, InvestmentPrinciple principle, Boolean isFollowed) {
         PrincipleCheck principleCheck = new PrincipleCheck();
         principleCheck.retrospection = retrospection;
         principleCheck.principle = principle;

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlegroup/dto/CreatePrincipleGroupCommand.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlegroup/dto/CreatePrincipleGroupCommand.java
@@ -1,0 +1,16 @@
+package com.ogd.stockdiary.domain.principlegroup.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CreatePrincipleGroupCommand {
+
+    private Long userId;
+    private String groupName;
+    private Integer displayOrder;
+    private List<String> principles; // optional
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlegroup/dto/ReorderPrincipleGroupsCommand.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlegroup/dto/ReorderPrincipleGroupsCommand.java
@@ -1,0 +1,21 @@
+package com.ogd.stockdiary.domain.principlegroup.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ReorderPrincipleGroupsCommand {
+
+    private Long userId;
+    private List<GroupOrder> groupOrders;
+
+    @Getter
+    @AllArgsConstructor
+    public static class GroupOrder {
+        private Long groupId;
+        private Integer displayOrder;
+    }
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlegroup/dto/UpdatePrincipleGroupCommand.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlegroup/dto/UpdatePrincipleGroupCommand.java
@@ -1,0 +1,13 @@
+package com.ogd.stockdiary.domain.principlegroup.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UpdatePrincipleGroupCommand {
+
+    private Long groupId;
+    private Long userId;
+    private String groupName;
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlegroup/entity/PrincipleGroup.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlegroup/entity/PrincipleGroup.java
@@ -1,0 +1,73 @@
+package com.ogd.stockdiary.domain.principlegroup.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+
+import com.ogd.stockdiary.domain.user.entity.User;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "principle_groups")
+@Getter
+@NoArgsConstructor
+public class PrincipleGroup {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private String groupName;
+
+    @Column(nullable = false)
+    private Integer displayOrder;
+
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public static PrincipleGroup create(User user, String groupName, Integer displayOrder) {
+        PrincipleGroup principleGroup = new PrincipleGroup();
+        principleGroup.user = user;
+        principleGroup.groupName = groupName;
+        principleGroup.displayOrder = displayOrder;
+        return principleGroup;
+    }
+
+    public void updateGroupName(String groupName) {
+        this.groupName = groupName;
+    }
+
+    public void updateDisplayOrder(Integer displayOrder) {
+        this.displayOrder = displayOrder;
+    }
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlegroup/port/out/PrincipleGroupRepository.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlegroup/port/out/PrincipleGroupRepository.java
@@ -1,0 +1,17 @@
+package com.ogd.stockdiary.domain.principlegroup.port.out;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.ogd.stockdiary.domain.principlegroup.entity.PrincipleGroup;
+
+public interface PrincipleGroupRepository {
+
+    List<PrincipleGroup> findByUserId(Long userId);
+
+    PrincipleGroup save(PrincipleGroup principleGroup);
+
+    Optional<PrincipleGroup> findByIdAndUserId(Long groupId, Long userId);
+
+    void deleteByIdAndUserId(Long groupId, Long userId);
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlegroup/service/PrincipleGroupService.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlegroup/service/PrincipleGroupService.java
@@ -1,0 +1,128 @@
+package com.ogd.stockdiary.domain.principlegroup.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ogd.stockdiary.application.user.repository.UserRepository;
+import com.ogd.stockdiary.common.httpresponse.CodeEnum;
+import com.ogd.stockdiary.domain.investmentprinciple.entity.InvestmentPrinciple;
+import com.ogd.stockdiary.domain.investmentprinciple.port.out.InvestmentPrincipleRepository;
+import com.ogd.stockdiary.domain.principlegroup.dto.CreatePrincipleGroupCommand;
+import com.ogd.stockdiary.domain.principlegroup.dto.ReorderPrincipleGroupsCommand;
+import com.ogd.stockdiary.domain.principlegroup.dto.UpdatePrincipleGroupCommand;
+import com.ogd.stockdiary.domain.principlegroup.entity.PrincipleGroup;
+import com.ogd.stockdiary.domain.principlegroup.port.out.PrincipleGroupRepository;
+import com.ogd.stockdiary.domain.principlegroup.usecase.PrincipleGroupUseCase;
+import com.ogd.stockdiary.domain.user.entity.User;
+import com.ogd.stockdiary.exception.ApplicationException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class PrincipleGroupService implements PrincipleGroupUseCase {
+
+    private final PrincipleGroupRepository principleGroupRepository;
+    private final InvestmentPrincipleRepository investmentPrincipleRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<PrincipleGroup> getUserPrincipleGroups(Long userId) {
+        return principleGroupRepository.findByUserId(userId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PrincipleGroup getPrincipleGroupById(Long groupId, Long userId) {
+        return principleGroupRepository
+            .findByIdAndUserId(groupId, userId)
+            .orElseThrow(
+                () -> new ApplicationException(
+                    CodeEnum.FRS_003, "투자원칙 그룹을 찾을 수 없습니다: " + groupId));
+    }
+
+    @Override
+    public PrincipleGroup createPrincipleGroup(CreatePrincipleGroupCommand command) {
+        User user = userRepository
+            .findById(command.getUserId())
+            .orElseThrow(
+                () -> new ApplicationException(
+                    CodeEnum.FRS_003,
+                    "사용자를 찾을 수 없습니다: " + command.getUserId()));
+
+        // 그룹 생성 시 원칙 개수 검증
+        if (command.getPrinciples() != null
+            && command.getPrinciples().size() > InvestmentPrinciple.MAX_PRINCIPLES_PER_GROUP) {
+            throw new ApplicationException(
+                CodeEnum.FRS_005,
+                "그룹당 최대 " + InvestmentPrinciple.MAX_PRINCIPLES_PER_GROUP + "개의 투자원칙만 추가할 수 있습니다");
+        }
+
+        // 그룹 생성
+        PrincipleGroup principleGroup = PrincipleGroup.create(user, command.getGroupName(), command.getDisplayOrder());
+        PrincipleGroup savedGroup = principleGroupRepository.save(principleGroup);
+
+        // 원칙들이 있으면 함께 생성
+        if (command.getPrinciples() != null && !command.getPrinciples().isEmpty()) {
+            List<InvestmentPrinciple> principles = IntStream.range(0, command.getPrinciples().size())
+                .mapToObj(
+                    index -> InvestmentPrinciple.create(
+                        user,
+                        savedGroup,
+                        command.getPrinciples().get(index),
+                        index))
+                .collect(Collectors.toList());
+
+            investmentPrincipleRepository.saveAll(principles);
+        }
+
+        return savedGroup;
+    }
+
+    @Override
+    public PrincipleGroup updatePrincipleGroup(UpdatePrincipleGroupCommand command) {
+        PrincipleGroup principleGroup = principleGroupRepository
+            .findByIdAndUserId(command.getGroupId(), command.getUserId())
+            .orElseThrow(
+                () -> new ApplicationException(
+                    CodeEnum.FRS_003,
+                    "투자원칙 그룹을 찾을 수 없습니다: " + command.getGroupId()));
+
+        principleGroup.updateGroupName(command.getGroupName());
+        return principleGroup;
+    }
+
+    @Override
+    public void deletePrincipleGroup(Long groupId, Long userId) {
+        if (!principleGroupRepository.findByIdAndUserId(groupId, userId).isPresent()) {
+            throw new ApplicationException(CodeEnum.FRS_003, "투자원칙 그룹을 찾을 수 없습니다: " + groupId);
+        }
+
+        // 그룹에 속한 원칙들 먼저 삭제
+        investmentPrincipleRepository.deleteByPrincipleGroupId(groupId);
+
+        // 그룹 삭제
+        principleGroupRepository.deleteByIdAndUserId(groupId, userId);
+    }
+
+    @Override
+    public void reorderPrincipleGroups(ReorderPrincipleGroupsCommand command) {
+        for (ReorderPrincipleGroupsCommand.GroupOrder groupOrder : command.getGroupOrders()) {
+            PrincipleGroup principleGroup = principleGroupRepository
+                .findByIdAndUserId(groupOrder.getGroupId(), command.getUserId())
+                .orElseThrow(
+                    () -> new ApplicationException(
+                        CodeEnum.FRS_003,
+                        "투자원칙 그룹을 찾을 수 없습니다: "
+                            + groupOrder.getGroupId()));
+
+            principleGroup.updateDisplayOrder(groupOrder.getDisplayOrder());
+        }
+    }
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlegroup/usecase/PrincipleGroupUseCase.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlegroup/usecase/PrincipleGroupUseCase.java
@@ -1,0 +1,23 @@
+package com.ogd.stockdiary.domain.principlegroup.usecase;
+
+import java.util.List;
+
+import com.ogd.stockdiary.domain.principlegroup.dto.CreatePrincipleGroupCommand;
+import com.ogd.stockdiary.domain.principlegroup.dto.ReorderPrincipleGroupsCommand;
+import com.ogd.stockdiary.domain.principlegroup.dto.UpdatePrincipleGroupCommand;
+import com.ogd.stockdiary.domain.principlegroup.entity.PrincipleGroup;
+
+public interface PrincipleGroupUseCase {
+
+    List<PrincipleGroup> getUserPrincipleGroups(Long userId);
+
+    PrincipleGroup getPrincipleGroupById(Long groupId, Long userId);
+
+    PrincipleGroup createPrincipleGroup(CreatePrincipleGroupCommand command);
+
+    PrincipleGroup updatePrincipleGroup(UpdatePrincipleGroupCommand command);
+
+    void deletePrincipleGroup(Long groupId, Long userId);
+
+    void reorderPrincipleGroups(ReorderPrincipleGroupsCommand command);
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/report/entity/Feedback.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/report/entity/Feedback.java
@@ -35,11 +35,11 @@ public class Feedback {
 
     @Builder
     public Feedback(
-            String feedback,
-            String summerizedFeedback,
-            String market,
-            String principles,
-            Retrospection retrospection) {
+        String feedback,
+        String summerizedFeedback,
+        String market,
+        String principles,
+        Retrospection retrospection) {
         this.feedback = feedback;
         this.summerizedFeedback = summerizedFeedback;
         this.market = market;

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/report/entity/RetrospectionForReport.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/report/entity/RetrospectionForReport.java
@@ -24,8 +24,9 @@ public class RetrospectionForReport {
     private String market;
 
     private String content;
-    
-    @Embedded private Order order;
+
+    @Embedded
+    private Order order;
 
     public RetrospectionForReport(String symbol, String market, Order order, String content) {
         this.symbol = symbol;

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/report/port/in/CreateFeedbackCommand.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/report/port/in/CreateFeedbackCommand.java
@@ -1,3 +1,4 @@
 package com.ogd.stockdiary.domain.report.port.in;
 
-public record CreateFeedbackCommand(Long retrospectionId) {}
+public record CreateFeedbackCommand(Long retrospectionId) {
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/report/port/out/ReportPromptLoader.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/report/port/out/ReportPromptLoader.java
@@ -14,8 +14,7 @@ public class ReportPromptLoader {
 
     public ReportPromptLoader(ResourceLoader resourceLoader) throws Exception {
 
-        Resource resource =
-                resourceLoader.getResource("classpath:RetrospectionForReportPrompt.txt");
+        Resource resource = resourceLoader.getResource("classpath:RetrospectionForReportPrompt.txt");
 
         this.prompt = new String(resource.getInputStream().readAllBytes(), "UTF-8");
     }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/retrospection/entity/Currency.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/retrospection/entity/Currency.java
@@ -1,8 +1,5 @@
 package com.ogd.stockdiary.domain.retrospection.entity;
 
 public enum Currency {
-    KRW,
-    USD,
-    EUR,
-    JPY
+    KRW, USD, EUR, JPY
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/retrospection/entity/InvestmentEmotion.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/retrospection/entity/InvestmentEmotion.java
@@ -6,11 +6,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum InvestmentEmotion {
-    ANXIETY(1, "불안"),
-    IMPULSE(2, "충동"),
-    MINDLESSNESS(3, "무념무상"),
-    CONFIDENCE(4, "자신감"),
-    CONVICTION(5, "확신");
+    ANXIETY(1, "불안"), IMPULSE(2, "충동"), MINDLESSNESS(3, "무념무상"), CONFIDENCE(4, "자신감"), CONVICTION(5, "확신");
 
     private final int value;
     private final String description;

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/retrospection/entity/Order.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/retrospection/entity/Order.java
@@ -34,11 +34,11 @@ public class Order {
     private LocalDate orderDate;
 
     public Order(
-            OrderType orderType,
-            BigDecimal price,
-            Currency currency,
-            Integer volume,
-            LocalDate orderDate) {
+        OrderType orderType,
+        BigDecimal price,
+        Currency currency,
+        Integer volume,
+        LocalDate orderDate) {
         validatePrice(price);
         validateVolume(volume);
 

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/retrospection/entity/OrderType.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/retrospection/entity/OrderType.java
@@ -1,6 +1,5 @@
 package com.ogd.stockdiary.domain.retrospection.entity;
 
 public enum OrderType {
-    BUY,
-    SELL
+    BUY, SELL
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/retrospection/entity/Retrospection.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/retrospection/entity/Retrospection.java
@@ -42,7 +42,8 @@ public class Retrospection {
     @Column(nullable = false, length = 20)
     private String market;
 
-    @Embedded private Order order;
+    @Embedded
+    private Order order;
 
     private Double returnRate;
 
@@ -70,13 +71,13 @@ public class Retrospection {
     }
 
     public Retrospection(
-            User user,
-            String symbol,
-            String market,
-            Order order,
-            Double returnRate,
-            String content,
-            InvestmentEmotion emotion) {
+        User user,
+        String symbol,
+        String market,
+        Order order,
+        Double returnRate,
+        String content,
+        InvestmentEmotion emotion) {
         this.user = user;
         this.symbol = symbol;
         this.market = market;

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/stock/dto/StockInterval.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/stock/dto/StockInterval.java
@@ -1,9 +1,7 @@
 package com.ogd.stockdiary.domain.stock.dto;
 
 public enum StockInterval {
-    DAILY("0"),
-    WEEKLY("1"),
-    MONTHLY("2");
+    DAILY("0"), WEEKLY("1"), MONTHLY("2");
 
     private final String code;
 

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/stock/entity/Market.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/stock/entity/Market.java
@@ -1,8 +1,5 @@
 package com.ogd.stockdiary.domain.stock.entity;
 
 public enum Market {
-    KOSPI,
-    KOSDAQ,
-    NAS,
-    NYSE
+    KOSPI, KOSDAQ, NAS, NYSE
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/stock/entity/Stock.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/stock/entity/Stock.java
@@ -17,13 +17,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(
-        name = "stock",
-        uniqueConstraints = {
-            @UniqueConstraint(
-                    name = "uk_market_code",
-                    columnNames = {"market", "code"})
-        })
+@Table(name = "stock", uniqueConstraints = {
+    @UniqueConstraint(name = "uk_market_code", columnNames = {"market", "code"})
+})
 @Getter
 @NoArgsConstructor
 public class Stock {

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/stock/port/out/StockPort.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/stock/port/out/StockPort.java
@@ -9,5 +9,5 @@ public interface StockPort {
     String getToken();
 
     StockChartData getChartData(
-            String market, String symbol, LocalDate endDate, StockInterval interval);
+        String market, String symbol, LocalDate endDate, StockInterval interval);
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/stock/service/ChartQueryService.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/stock/service/ChartQueryService.java
@@ -23,20 +23,18 @@ public class ChartQueryService implements ChartQueryUseCase {
 
     @Override
     public StockChartData getStockChart(
-            String market,
-            String symbol,
-            LocalDate startDate,
-            LocalDate endDate,
-            StockInterval interval) {
+        String market,
+        String symbol,
+        LocalDate startDate,
+        LocalDate endDate,
+        StockInterval interval) {
         StockChartData allData = stockPort.getChartData(market, symbol, endDate, interval);
 
-        List<StockChartItem> filteredChartData =
-                allData.getChartData().stream()
-                        .filter(
-                                item ->
-                                        !item.getDate().isBefore(startDate)
-                                                && !item.getDate().isAfter(endDate))
-                        .collect(Collectors.toList());
+        List<StockChartItem> filteredChartData = allData.getChartData().stream()
+            .filter(
+                item -> !item.getDate().isBefore(startDate)
+                    && !item.getDate().isAfter(endDate))
+            .collect(Collectors.toList());
 
         return new StockChartData(allData.getCurrency(), filteredChartData);
     }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/stock/service/StockQueryService.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/stock/service/StockQueryService.java
@@ -25,12 +25,10 @@ public class StockQueryService implements StockQueryUseCase {
 
     @Override
     public SliceContent<StockSearchResponse> findByCompanyNameSlice(
-            String nextCursor, String companyName, int size) {
-        SliceContent<Stock> stockSlice =
-                stockRepository.findByCompanyNameSlice(nextCursor, companyName, size);
+        String nextCursor, String companyName, int size) {
+        SliceContent<Stock> stockSlice = stockRepository.findByCompanyNameSlice(nextCursor, companyName, size);
 
-        List<StockSearchResponse> responseList =
-                stockSlice.content().stream().map(StockSearchResponse::from).toList();
+        List<StockSearchResponse> responseList = stockSlice.content().stream().map(StockSearchResponse::from).toList();
 
         return new SliceContent<>(responseList, stockSlice.nextCursor());
     }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/stock/usecase/ChartQueryUseCase.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/stock/usecase/ChartQueryUseCase.java
@@ -8,9 +8,9 @@ import com.ogd.stockdiary.domain.stock.dto.StockInterval;
 public interface ChartQueryUseCase {
 
     StockChartData getStockChart(
-            String market,
-            String symbol,
-            LocalDate startDate,
-            LocalDate endDate,
-            StockInterval interval);
+        String market,
+        String symbol,
+        LocalDate startDate,
+        LocalDate endDate,
+        StockInterval interval);
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/stock/usecase/StockQueryUseCase.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/stock/usecase/StockQueryUseCase.java
@@ -10,5 +10,5 @@ public interface StockQueryUseCase {
     List<Stock> findByCompanyNameLike(String companyName);
 
     SliceContent<StockSearchResponse> findByCompanyNameSlice(
-            String nextCursor, String companyName, int size);
+        String nextCursor, String companyName, int size);
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/user/entity/OAuthProvider.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/user/entity/OAuthProvider.java
@@ -1,7 +1,5 @@
 package com.ogd.stockdiary.domain.user.entity;
 
 public enum OAuthProvider {
-    GOOGLE,
-    KAKAO,
-    APPLE,
+    GOOGLE, KAKAO, APPLE,
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/user/entity/User.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/user/entity/User.java
@@ -36,7 +36,8 @@ public class User {
     @Column(name = "profile_image_url", length = 500)
     private String profileImageUrl;
 
-    @Embedded private OAuthProviderInfo oAuthProviderInfo;
+    @Embedded
+    private OAuthProviderInfo oAuthProviderInfo;
 
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
@@ -60,10 +61,10 @@ public class User {
     }
 
     public User(
-            String nickname,
-            String email,
-            String profileImageUrl,
-            OAuthProviderInfo oAuthProviderInfo) {
+        String nickname,
+        String email,
+        String profileImageUrl,
+        OAuthProviderInfo oAuthProviderInfo) {
         this.nickname = nickname;
         this.email = email;
         this.profileImageUrl = profileImageUrl;

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/user/port/out/oauth/client/OAuthClientFactory.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/user/port/out/oauth/client/OAuthClientFactory.java
@@ -17,7 +17,7 @@ public class OAuthClientFactory {
         return switch (provider) {
             case APPLE -> appleOAuthClient;
             case GOOGLE, KAKAO ->
-                    throw new UnsupportedOperationException(provider + " not implemented yet");
+                throw new UnsupportedOperationException(provider + " not implemented yet");
         };
     }
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/user/service/AuthService.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/user/service/AuthService.java
@@ -30,7 +30,7 @@ public class AuthService {
 
     @Transactional
     public AuthResult socialLogin(
-            OAuthProvider provider, String authCode, String email, String nickname) {
+        OAuthProvider provider, String authCode, String email, String nickname) {
         OAuthClient client = oAuthClientFactory.getClient(provider);
 
         // 1. 토큰 획득
@@ -40,20 +40,17 @@ public class AuthService {
         OIDCPublicKeyList publicKeys = client.getPublicKeys();
 
         // 3. ID 토큰 검증
-        OIDCPayload payload =
-                oidcTokenVerification.verifyIdToken(tokenResponse.getIdToken(), publicKeys);
+        OIDCPayload payload = oidcTokenVerification.verifyIdToken(tokenResponse.getIdToken(), publicKeys);
 
         // 4. 기존 사용자 확인
-        boolean isNewUser =
-                !userRepository
-                        .findByOAuthProviderAndSubject(provider, payload.getSubject())
-                        .isPresent();
+        boolean isNewUser = !userRepository
+            .findByOAuthProviderAndSubject(provider, payload.getSubject())
+            .isPresent();
 
         // 5. 회원 조회 또는 생성
-        User user =
-                userRepository
-                        .findByOAuthProviderAndSubject(provider, payload.getSubject())
-                        .orElseGet(() -> createNewUser(provider, payload, email, nickname));
+        User user = userRepository
+            .findByOAuthProviderAndSubject(provider, payload.getSubject())
+            .orElseGet(() -> createNewUser(provider, payload, email, nickname));
 
         // 6. Apple의 경우 refresh token 저장
         if (provider == OAuthProvider.APPLE && tokenResponse.getRefreshToken() != null) {
@@ -64,10 +61,10 @@ public class AuthService {
     }
 
     private User createNewUser(
-            OAuthProvider provider,
-            OIDCPayload payload,
-            String providedEmail,
-            String providedNickname) {
+        OAuthProvider provider,
+        OIDCPayload payload,
+        String providedEmail,
+        String providedNickname) {
         String email = payload.getEmail() != null ? payload.getEmail() : providedEmail;
         String nickname = payload.getName() != null ? payload.getName() : providedNickname;
 
@@ -92,23 +89,20 @@ public class AuthService {
 
     @Transactional
     public void unlinkSocialAccount(Long userId) {
-        User user =
-                userRepository
-                        .findById(userId)
-                        .orElseThrow(() -> new IllegalArgumentException("User not found"));
+        User user = userRepository
+            .findById(userId)
+            .orElseThrow(() -> new IllegalArgumentException("User not found"));
 
         OAuthProvider provider = user.getOAuthProviderInfo().getOauthProvider();
         OAuthClient client = oAuthClientFactory.getClient(provider);
 
         if (provider == OAuthProvider.APPLE) {
             // Apple의 경우 저장된 refresh token으로 연결 해제
-            AppleAuthToken appleAuthToken =
-                    appleAuthTokenRepository
-                            .findById(userId)
-                            .orElseThrow(
-                                    () ->
-                                            new IllegalArgumentException(
-                                                    "Apple auth token not found"));
+            AppleAuthToken appleAuthToken = appleAuthTokenRepository
+                .findById(userId)
+                .orElseThrow(
+                    () -> new IllegalArgumentException(
+                        "Apple auth token not found"));
 
             client.unlink(appleAuthToken.getRefreshToken());
             appleAuthTokenRepository.delete(appleAuthToken);

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/user/service/OIDCTokenVerification.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/user/service/OIDCTokenVerification.java
@@ -36,27 +36,25 @@ public class OIDCTokenVerification {
             String kid = (String) headerMap.get("kid");
             String alg = (String) headerMap.get("alg");
 
-            OIDCPublicKey matchingKey =
-                    oidcPublicKeys.getKeys().stream()
-                            .filter(key -> key.getKid().equals(kid))
-                            .findFirst()
-                            .orElseThrow(
-                                    () -> new RuntimeException("No matching public key found"));
+            OIDCPublicKey matchingKey = oidcPublicKeys.getKeys().stream()
+                .filter(key -> key.getKid().equals(kid))
+                .findFirst()
+                .orElseThrow(
+                    () -> new RuntimeException("No matching public key found"));
 
             PublicKey publicKey = generateRSAPublicKey(matchingKey.getN(), matchingKey.getE());
 
-            Claims claims =
-                    Jwts.parserBuilder()
-                            .setSigningKey(publicKey)
-                            .build()
-                            .parseClaimsJws(idToken)
-                            .getBody();
+            Claims claims = Jwts.parserBuilder()
+                .setSigningKey(publicKey)
+                .build()
+                .parseClaimsJws(idToken)
+                .getBody();
 
             return new OIDCPayload(
-                    claims.getSubject(),
-                    claims.get("email", String.class),
-                    claims.get("picture", String.class),
-                    claims.get("name", String.class));
+                claims.getSubject(),
+                claims.get("email", String.class),
+                claims.get("picture", String.class),
+                claims.get("name", String.class));
 
         } catch (ExpiredJwtException e) {
             log.error("ID token has expired", e);
@@ -74,7 +72,7 @@ public class OIDCTokenVerification {
     }
 
     private PublicKey generateRSAPublicKey(String n, String e)
-            throws NoSuchAlgorithmException, InvalidKeySpecException {
+        throws NoSuchAlgorithmException, InvalidKeySpecException {
         byte[] nBytes = Base64.getUrlDecoder().decode(n);
         byte[] eBytes = Base64.getUrlDecoder().decode(e);
 

--- a/stock-diary/src/main/java/com/ogd/stockdiary/exception/ApplicationException.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/exception/ApplicationException.java
@@ -9,7 +9,8 @@ import lombok.Getter;
 @Getter
 public class ApplicationException extends RuntimeException {
     private final CodeEnum code;
-    @Getter private final Map<String, Object> data;
+    @Getter
+    private final Map<String, Object> data;
 
     public ApplicationException(CodeEnum code, String message, Map<String, Object> data) {
         super(message);

--- a/stock-diary/src/test/java/com/ogd/stockdiary/StockDiaryApplicationTests.java
+++ b/stock-diary/src/test/java/com/ogd/stockdiary/StockDiaryApplicationTests.java
@@ -7,5 +7,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 class StockDiaryApplicationTests {
 
     @Test
-    void contextLoads() {}
+    void contextLoads() {
+    }
 }

--- a/stock-diary/src/test/java/com/ogd/stockdiary/domain/retrospection/entity/OrderTest.java
+++ b/stock-diary/src/test/java/com/ogd/stockdiary/domain/retrospection/entity/OrderTest.java
@@ -44,8 +44,8 @@ class OrderTest {
 
         // when & then
         assertThatThrownBy(() -> new Order(orderType, invalidPrice, currency, volume, orderDate))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("가격은 0보다 큰 값이어야 합니다.");
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("가격은 0보다 큰 값이어야 합니다.");
     }
 
     @Test
@@ -60,8 +60,8 @@ class OrderTest {
 
         // when & then
         assertThatThrownBy(() -> new Order(orderType, price, currency, invalidVolume, orderDate))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("거래량은 0보다 큰 값이어야 합니다.");
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("거래량은 0보다 큰 값이어야 합니다.");
     }
 
     @Test
@@ -76,8 +76,8 @@ class OrderTest {
 
         // when & then
         assertThatThrownBy(() -> new Order(orderType, nullPrice, currency, volume, orderDate))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("가격은 0보다 큰 값이어야 합니다.");
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("가격은 0보다 큰 값이어야 합니다.");
     }
 
     @Test
@@ -92,7 +92,7 @@ class OrderTest {
 
         // when & then
         assertThatThrownBy(() -> new Order(orderType, price, currency, nullVolume, orderDate))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("거래량은 0보다 큰 값이어야 합니다.");
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("거래량은 0보다 큰 값이어야 합니다.");
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- Jira Ticket: [OGD-28](https://depromeet05.atlassian.net/browse/OGD-28)

## 🔍 PR의 이유
  - 투자원칙을 그룹으로 관리하고 순서를 변경할 수 있는 기능이 필요
  - 코드 가독성 향상을 위해 코드 포맷터 변경 필요 (8칸 들여쓰기 → 4칸)

## ✨ 주요 변경사항
- [ ] 투자원칙 그룹(PrincipleGroup) 도메인 엔티티 및 CRUD API 추가
- [ ] 투자원칙 그룹 생성 시 최대 5개 원칙 제한 검증 로직 추가
- [ ] 투자원칙 그룹 삭제 시 속한 원칙들도 함께 삭제되도록 cascade
처리
- [ ] 투자원칙 및 그룹의 순서 변경(reorder) API 추가
- [ ] InvestmentPrinciple 엔티티에 displayOrder 필드 추가
- [ ] PrincipleGroup 엔티티에 displayOrder 필드 추가
- [ ] 응답 DTO에서 createdAt, updatedAt 필드 제거
- [ ] 코드 포맷터를 Google AOSP에서 Eclipse로 변경 (4칸 들여쓰기)
- [ ] Swagger API 문서에 그룹당 최대 5개 원칙 제약사항 명시

## 📎 참고(선택)
- 그룹 없이 독립적인 투자원칙 생성도 여전히 가능
- displayOrder는 클라이언트에서 관리하며, 서버는 클라이언트가
전달한 순서를 저장
- 일괄 순서 변경 API는 트랜잭션으로 원자적 업데이트 보장