### PR TITLE
[OGD-31] 이미지 업로드 API 만들기

### DIFF
--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/image/controller/ImageController.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/image/controller/ImageController.java
@@ -1,0 +1,54 @@
+package com.ogd.stockdiary.application.image.controller;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.ogd.stockdiary.application.image.dto.ImageUploadResponse;
+import com.ogd.stockdiary.common.httpresponse.HttpApiResponse;
+import com.ogd.stockdiary.domain.image.dto.UploadImageCommand;
+import com.ogd.stockdiary.domain.image.entity.ImageMetadata;
+import com.ogd.stockdiary.domain.image.port.in.ImageUseCase;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Image", description = "이미지 업로드 API")
+@RestController
+@RequestMapping("/api/v1/{domain}/images")
+@RequiredArgsConstructor
+public class ImageController {
+
+    private final ImageUseCase imageUseCase;
+
+    @Operation(summary = "이미지 업로드", description = "이미지를 업로드하고 메타데이터를 저장합니다. 업로드된 이미지는 임시 상태(T)로 저장됩니다.")
+    @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<HttpApiResponse<ImageUploadResponse>> uploadImage(
+        @PathVariable String domain, @RequestParam("file") MultipartFile file) throws Exception {
+
+        // TODO: Spring Security에서 User 정보 가져오기
+        Long userId = 1L; // 임시로 하드코딩
+
+        // UploadImageCommand 생성
+        UploadImageCommand command = new UploadImageCommand(
+            userId, domain, file.getOriginalFilename(), file.getSize(), file.getInputStream());
+
+        // 이미지 업로드
+        ImageMetadata imageMetadata = imageUseCase.uploadImage(command);
+
+        // 응답 생성
+        ImageUploadResponse response = new ImageUploadResponse(
+            imageMetadata.getId(),
+            imageMetadata.getObjectKey(),
+            imageMetadata.getFileName(),
+            imageMetadata.getFileSize());
+
+        return ResponseEntity.ok(HttpApiResponse.of(response));
+    }
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/image/dto/ImageUploadResponse.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/image/dto/ImageUploadResponse.java
@@ -1,0 +1,14 @@
+package com.ogd.stockdiary.application.image.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ImageUploadResponse {
+
+    private final Long imageId;
+    private final String objectKey;
+    private final String fileName;
+    private final Long fileSize;
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/image/repository/ImageRepositoryImpl.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/image/repository/ImageRepositoryImpl.java
@@ -1,0 +1,20 @@
+package com.ogd.stockdiary.application.image.repository;
+
+import org.springframework.stereotype.Repository;
+
+import com.ogd.stockdiary.domain.image.entity.ImageMetadata;
+import com.ogd.stockdiary.domain.image.port.out.ImageRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class ImageRepositoryImpl implements ImageRepository {
+
+    private final JpaImageMetadataRepository jpaImageMetadataRepository;
+
+    @Override
+    public ImageMetadata save(ImageMetadata imageMetadata) {
+        return jpaImageMetadataRepository.save(imageMetadata);
+    }
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/image/repository/JpaImageMetadataRepository.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/image/repository/JpaImageMetadataRepository.java
@@ -1,0 +1,11 @@
+package com.ogd.stockdiary.application.image.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.ogd.stockdiary.domain.image.entity.ImageMetadata;
+
+@Repository
+public interface JpaImageMetadataRepository extends JpaRepository<ImageMetadata, Long> {
+
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/image/repository/JpaPrincipleCheckImageRepository.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/image/repository/JpaPrincipleCheckImageRepository.java
@@ -1,0 +1,11 @@
+package com.ogd.stockdiary.application.image.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.ogd.stockdiary.domain.image.entity.PrincipleCheckImage;
+
+@Repository
+public interface JpaPrincipleCheckImageRepository extends JpaRepository<PrincipleCheckImage, Long> {
+
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/image/service/ImageService.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/image/service/ImageService.java
@@ -1,0 +1,87 @@
+package com.ogd.stockdiary.application.image.service;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ogd.stockdiary.application.user.repository.UserRepository;
+import com.ogd.stockdiary.common.httpresponse.CodeEnum;
+import com.ogd.stockdiary.domain.fileclient.port.out.FileClientPort;
+import com.ogd.stockdiary.domain.image.dto.UploadImageCommand;
+import com.ogd.stockdiary.domain.image.entity.ImageMetadata;
+import com.ogd.stockdiary.domain.image.entity.ImageStatus;
+import com.ogd.stockdiary.domain.image.port.in.ImageUseCase;
+import com.ogd.stockdiary.domain.image.port.out.ImageRepository;
+import com.ogd.stockdiary.domain.user.entity.User;
+import com.ogd.stockdiary.exception.ApplicationException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ImageService implements ImageUseCase {
+
+    private static final int UUID_SUBSTRING_LENGTH = 12;
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+    private final ImageRepository imageRepository;
+    private final FileClientPort fileClientPort;
+    private final UserRepository userRepository;
+
+    @Override
+    public ImageMetadata uploadImage(UploadImageCommand command) {
+        // 사용자 조회
+        User user = userRepository.findById(command.getUserId())
+            .orElseThrow(() -> new ApplicationException(CodeEnum.FRS_003, "사용자를 찾을 수 없습니다: " + command.getUserId()));
+
+        // 파일명에서 확장자 추출
+        String fileName = command.getFileName();
+        String extension = extractFileExtension(fileName);
+
+        // UUID 생성 및 짧게 자르기
+        String shortUuid = generateShortUuid();
+
+        // objectKey 생성: /{domain}/{yyyy-MM-dd}/{shortUuid}.{extension}
+        String currentDate = LocalDate.now().format(DATE_FORMATTER);
+        String objectKey = String.format(
+            "/%s/%s/%s.%s", command.getDomain(), currentDate, shortUuid, extension);
+
+        // MinIO에 파일 업로드
+        fileClientPort.uploadFile(command.getInputStream(), objectKey, command.getFileSize());
+
+        // ImageMetadata 엔티티 생성 및 저장
+        ImageMetadata imageMetadata = ImageMetadata.create(
+            user, fileName, objectKey, command.getFileSize(), ImageStatus.T);
+
+        return imageRepository.save(imageMetadata);
+    }
+
+    /**
+     * 파일명에서 확장자를 추출합니다.
+     *
+     * @param fileName
+     *            파일명 (예: "image.png")
+     * @return 확장자 (예: "png")
+     */
+    private String extractFileExtension(String fileName) {
+        int lastDotIndex = fileName.lastIndexOf('.');
+        if (lastDotIndex == -1 || lastDotIndex == fileName.length() - 1) {
+            throw new ApplicationException(CodeEnum.FRS_003, "유효하지 않은 파일명입니다: " + fileName);
+        }
+        return fileName.substring(lastDotIndex + 1);
+    }
+
+    /**
+     * UUID를 생성하고 하이픈을 제거한 후 앞 12자를 반환합니다.
+     *
+     * @return 짧은 UUID (예: "a1b2c3d45678")
+     */
+    private String generateShortUuid() {
+        String uuid = UUID.randomUUID().toString().replace("-", "");
+        return uuid.substring(0, UUID_SUBSTRING_LENGTH);
+    }
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/principlecheck/dto/request/PrincipleCheckRequest.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/principlecheck/dto/request/PrincipleCheckRequest.java
@@ -19,7 +19,8 @@ public class PrincipleCheckRequest {
     @NotNull(message = "투자원칙 ID는 필수입니다")
     private Long principleId;
 
-    @Schema(description = "투자원칙 준수 상태", example = "KEPT", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(description = "투자원칙 준수 상태 (KEPT: 지켰어요, NEUTRAL: 보통이에요, NOT_KEPT: 안지켰어요)", example = "KEPT", allowableValues = {
+        "KEPT", "NEUTRAL", "NOT_KEPT"}, requiredMode = Schema.RequiredMode.REQUIRED)
     @NotNull(message = "투자원칙 준수 상태는 필수입니다")
     private PrincipleCheckStatus status;
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/image/dto/UploadImageCommand.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/image/dto/UploadImageCommand.java
@@ -1,0 +1,17 @@
+package com.ogd.stockdiary.domain.image.dto;
+
+import java.io.InputStream;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class UploadImageCommand {
+
+    private final Long userId;
+    private final String domain;
+    private final String fileName;
+    private final Long fileSize;
+    private final InputStream inputStream;
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/image/entity/ImageMetadata.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/image/entity/ImageMetadata.java
@@ -1,0 +1,83 @@
+package com.ogd.stockdiary.domain.image.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+
+import com.ogd.stockdiary.domain.user.entity.User;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "image_metadata")
+@Getter
+@NoArgsConstructor
+public class ImageMetadata {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private User user;
+
+    @Column(name = "file_name", nullable = false)
+    private String fileName;
+
+    @Column(name = "object_key", nullable = false, unique = true)
+    private String objectKey;
+
+    @Column(name = "file_size", nullable = false)
+    private Long fileSize;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private ImageStatus status;
+
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public static ImageMetadata create(
+        User user, String fileName, String objectKey, Long fileSize, ImageStatus status) {
+        ImageMetadata imageMetadata = new ImageMetadata();
+        imageMetadata.user = user;
+        imageMetadata.fileName = fileName;
+        imageMetadata.objectKey = objectKey;
+        imageMetadata.fileSize = fileSize;
+        imageMetadata.status = status;
+        return imageMetadata;
+    }
+
+    public void updateStatus(ImageStatus status) {
+        this.status = status;
+    }
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/image/entity/ImageStatus.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/image/entity/ImageStatus.java
@@ -1,0 +1,18 @@
+package com.ogd.stockdiary.domain.image.entity;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@Schema(description = "이미지 상태")
+public enum ImageStatus {
+    T("임시저장"),
+
+    C("저장완료"),
+
+    D("삭제");
+
+    private final String description;
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/image/entity/PrincipleCheckImage.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/image/entity/PrincipleCheckImage.java
@@ -1,0 +1,55 @@
+package com.ogd.stockdiary.domain.image.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+
+import com.ogd.stockdiary.domain.principlecheck.entity.PrincipleCheck;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "principle_check_images")
+@Getter
+@NoArgsConstructor
+public class PrincipleCheckImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "principle_check_id", nullable = false, foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
+    private PrincipleCheck principleCheck;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "image_id", nullable = false, foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
+    private ImageMetadata image;
+
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public static PrincipleCheckImage create(PrincipleCheck principleCheck, ImageMetadata image) {
+        PrincipleCheckImage principleCheckImage = new PrincipleCheckImage();
+        principleCheckImage.principleCheck = principleCheck;
+        principleCheckImage.image = image;
+        return principleCheckImage;
+    }
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/image/port/in/ImageUseCase.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/image/port/in/ImageUseCase.java
@@ -1,0 +1,16 @@
+package com.ogd.stockdiary.domain.image.port.in;
+
+import com.ogd.stockdiary.domain.image.dto.UploadImageCommand;
+import com.ogd.stockdiary.domain.image.entity.ImageMetadata;
+
+public interface ImageUseCase {
+
+    /**
+     * 이미지를 업로드하고 메타데이터를 저장합니다.
+     *
+     * @param command
+     *            업로드 명령
+     * @return 저장된 이미지 메타데이터
+     */
+    ImageMetadata uploadImage(UploadImageCommand command);
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/image/port/out/ImageRepository.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/image/port/out/ImageRepository.java
@@ -1,0 +1,15 @@
+package com.ogd.stockdiary.domain.image.port.out;
+
+import com.ogd.stockdiary.domain.image.entity.ImageMetadata;
+
+public interface ImageRepository {
+
+    /**
+     * 이미지 메타데이터를 저장합니다.
+     *
+     * @param imageMetadata
+     *            저장할 이미지 메타데이터
+     * @return 저장된 이미지 메타데이터
+     */
+    ImageMetadata save(ImageMetadata imageMetadata);
+}


### PR DESCRIPTION
## 📌 관련 이슈
- Jira Ticket: [OGD-31](https://depromeet05.atlassian.net/browse/OGD-31)

## 🔍 PR의 이유
- 이미지 업로드 API 개발
- 투자원칙 체크 시 첨부할 이미지를 임시 저장하는 기능 구현

## ✨ 주요 변경사항
- [ ]  이미지 메타데이터 엔티티 추가 (ImageMetadata)
- [ ]  이미지 상태 관리 Enum 추가 (T: 임시저장, C: 저장완료, D:
삭제)
- [ ]  PrincipleCheck-Image 매핑 테이블 엔티티 추가 (FK 제약조건
없음)
- [ ]  이미지 업로드 API 구현 (POST
/api/v1/{domain}/images/upload)
- [ ]  UUID 기반 파일명 생성 로직 구현 (12자 단축)
- [ ]  도메인별 디렉토리 구조 생성
(/{domain}/{yyyy-MM-dd}/{uuid}.ext)
- [ ]  MinIO 파일 업로드 및 메타데이터 DB 저장 (임시 상태)

## 📎 참고(선택)
- ex) 관련 문서, 이슈 링크 등이 있다면 작성해주세요.