### PR TITLE
[OGD-32] v2 회고 API 만들기

### DIFF
--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/fileclient/adapter/MinioFileClientAdapter.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/fileclient/adapter/MinioFileClientAdapter.java
@@ -20,6 +20,7 @@ import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
@@ -71,10 +72,15 @@ public class MinioFileClientAdapter implements FileClientPort {
             .build();
 
         // MinIO용 S3 Presigner 생성
+        S3Configuration s3Config = S3Configuration.builder()
+            .pathStyleAccessEnabled(true) // MinIO는 path-style 필수
+            .build();
+
         this.s3Presigner = S3Presigner.builder()
             .endpointOverride(URI.create(endpoint))
             .region(Region.of(region))
             .credentialsProvider(credentialsProvider)
+            .serviceConfiguration(s3Config)
             .build();
 
         // AWS S3로 전환시 주석 해제:

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/fileclient/controller/FileClientTestController.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/fileclient/controller/FileClientTestController.java
@@ -68,9 +68,9 @@ public class FileClientTestController {
 
     @Operation(summary = "[TEST] 다운로드 URL 생성", description = "파일 다운로드를 위한 Pre-Signed URL을 생성합니다. "
         + "⚠️ 테스트 전용 - 추후 삭제 예정")
-    @GetMapping("/download-url/{objectKey}")
+    @GetMapping("/download-url")
     public ResponseEntity<HttpApiResponse<PreSignedUrlResponse>> createDownloadUrl(
-        @PathVariable String objectKey, @RequestParam(defaultValue = "3600") int ttl) {
+        @RequestParam String objectKey, @RequestParam(defaultValue = "3600") int ttl) {
 
         String url = fileClientTestUseCase.createDownloadUrl(objectKey, ttl);
 

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/image/repository/JpaPrincipleCheckImageRepository.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/image/repository/JpaPrincipleCheckImageRepository.java
@@ -1,5 +1,7 @@
 package com.ogd.stockdiary.application.image.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -8,4 +10,5 @@ import com.ogd.stockdiary.domain.image.entity.PrincipleCheckImage;
 @Repository
 public interface JpaPrincipleCheckImageRepository extends JpaRepository<PrincipleCheckImage, Long> {
 
+    List<PrincipleCheckImage> findByPrincipleCheckId(Long principleCheckId);
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/image/service/ImageService.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/image/service/ImageService.java
@@ -45,10 +45,10 @@ public class ImageService implements ImageUseCase {
         // UUID 생성 및 짧게 자르기
         String shortUuid = generateShortUuid();
 
-        // objectKey 생성: /{domain}/{yyyy-MM-dd}/{shortUuid}.{extension}
+        // objectKey 생성: {domain}/{yyyy-MM-dd}/{shortUuid}.{extension}
         String currentDate = LocalDate.now().format(DATE_FORMATTER);
         String objectKey = String.format(
-            "/%s/%s/%s.%s", command.getDomain(), currentDate, shortUuid, extension);
+            "%s/%s/%s.%s", command.getDomain(), currentDate, shortUuid, extension);
 
         // MinIO에 파일 업로드
         fileClientPort.uploadFile(command.getInputStream(), objectKey, command.getFileSize());
@@ -83,5 +83,10 @@ public class ImageService implements ImageUseCase {
     private String generateShortUuid() {
         String uuid = UUID.randomUUID().toString().replace("-", "");
         return uuid.substring(0, UUID_SUBSTRING_LENGTH);
+    }
+
+    @Override
+    public String getDownloadUrl(String objectKey) {
+        return fileClientPort.getDownloadPreSignedUrl(objectKey, 3600);
     }
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/principlecheck/dto/request/PrincipleCheckRequest.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/principlecheck/dto/request/PrincipleCheckRequest.java
@@ -1,6 +1,9 @@
 package com.ogd.stockdiary.application.principlecheck.dto.request;
 
+import java.util.List;
+
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 import com.ogd.stockdiary.domain.principlecheck.entity.PrincipleCheckStatus;
 
@@ -23,4 +26,15 @@ public class PrincipleCheckRequest {
         "KEPT", "NEUTRAL", "NOT_KEPT"}, requiredMode = Schema.RequiredMode.REQUIRED)
     @NotNull(message = "투자원칙 준수 상태는 필수입니다")
     private PrincipleCheckStatus status;
+
+    @Schema(description = "투자 이유", example = "기술적 분석 결과 상승 추세가 확인되어 매수했습니다.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String reason;
+
+    @Schema(description = "이미지 ID 목록 (최대 3개)", example = "[1, 2, 3]", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @Size(max = 3, message = "이미지는 최대 3개까지 등록할 수 있습니다")
+    private List<Long> imageIds;
+
+    @Schema(description = "링크 목록 (최대 3개)", example = "[\"https://example.com/article1\", \"https://example.com/article2\"]", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @Size(max = 3, message = "링크는 최대 3개까지 등록할 수 있습니다")
+    private List<String> links;
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/principlecheck/repository/JpaPrincipleCheckLinkRepository.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/principlecheck/repository/JpaPrincipleCheckLinkRepository.java
@@ -1,0 +1,8 @@
+package com.ogd.stockdiary.application.principlecheck.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.ogd.stockdiary.domain.principlecheck.entity.PrincipleCheckLink;
+
+public interface JpaPrincipleCheckLinkRepository extends JpaRepository<PrincipleCheckLink, Long> {
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/principlecheck/repository/JpaPrincipleCheckLinkRepository.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/principlecheck/repository/JpaPrincipleCheckLinkRepository.java
@@ -1,8 +1,12 @@
 package com.ogd.stockdiary.application.principlecheck.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.ogd.stockdiary.domain.principlecheck.entity.PrincipleCheckLink;
 
 public interface JpaPrincipleCheckLinkRepository extends JpaRepository<PrincipleCheckLink, Long> {
+
+    List<PrincipleCheckLink> findByPrincipleCheckId(Long principleCheckId);
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/dto/mapper/RetrospectionMapper.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/dto/mapper/RetrospectionMapper.java
@@ -40,7 +40,12 @@ public class RetrospectionMapper {
     }
 
     private static PrincipleCheckCommand toPrincipleCheckCommand(PrincipleCheckRequest request) {
-        return new PrincipleCheckCommand(request.getPrincipleId(), request.getStatus());
+        return new PrincipleCheckCommand(
+            request.getPrincipleId(),
+            request.getStatus(),
+            request.getReason(),
+            request.getImageIds(),
+            request.getLinks());
     }
 
     public static CreateRetrospectionResponse toResponse(Retrospection retrospection) {

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/dto/mapper/RetrospectionMapper.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/dto/mapper/RetrospectionMapper.java
@@ -2,6 +2,7 @@ package com.ogd.stockdiary.application.retrospection.dto.mapper;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import com.ogd.stockdiary.application.principlecheck.dto.request.PrincipleCheckRequest;
 import com.ogd.stockdiary.application.retrospection.dto.request.CreateRetrospectionRequest;
@@ -85,13 +86,18 @@ public class RetrospectionMapper {
     }
 
     public static GetRetrospectionResponse toGetResponse(
-        Retrospection retrospection, List<PrincipleCheck> principleChecks) {
+        Retrospection retrospection,
+        List<PrincipleCheck> principleChecks,
+        Map<Long, List<String>> imageUrlsMap,
+        Map<Long, List<String>> linksMap) {
         List<GetRetrospectionResponse.PrincipleCheckResponse> principleCheckResponses = principleChecks.stream()
-            .map(
-                pc -> new GetRetrospectionResponse.PrincipleCheckResponse(
-                    pc.getPrinciple().getId(),
-                    pc.getPrinciple().getPrinciple(),
-                    pc.getStatus()))
+            .map(pc -> new GetRetrospectionResponse.PrincipleCheckResponse(
+                pc.getPrinciple().getId(),
+                pc.getPrinciple().getPrinciple(),
+                pc.getStatus(),
+                pc.getReason(),
+                imageUrlsMap.getOrDefault(pc.getId(), Collections.emptyList()),
+                linksMap.getOrDefault(pc.getId(), Collections.emptyList())))
             .toList();
 
         return new GetRetrospectionResponse(

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/dto/response/GetRetrospectionResponse.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/dto/response/GetRetrospectionResponse.java
@@ -77,5 +77,14 @@ public class GetRetrospectionResponse {
 
         @Schema(description = "투자 원칙 준수 상태", example = "KEPT")
         private PrincipleCheckStatus status;
+
+        @Schema(description = "투자 이유", example = "기술적 분석 결과 상승 추세가 확인되어 매수했습니다.")
+        private String reason;
+
+        @Schema(description = "이미지 다운로드 URL 목록", example = "[\"https://example.com/image1.png\", \"https://example.com/image2.png\"]")
+        private List<String> imageUrls;
+
+        @Schema(description = "링크 목록", example = "[\"https://example.com/article1\", \"https://example.com/article2\"]")
+        private List<String> links;
     }
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/service/RetrospectionService.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/service/RetrospectionService.java
@@ -1,6 +1,8 @@
 package com.ogd.stockdiary.application.retrospection.service;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,6 +18,7 @@ import com.ogd.stockdiary.common.httpresponse.CodeEnum;
 import com.ogd.stockdiary.domain.image.entity.ImageMetadata;
 import com.ogd.stockdiary.domain.image.entity.ImageStatus;
 import com.ogd.stockdiary.domain.image.entity.PrincipleCheckImage;
+import com.ogd.stockdiary.domain.image.port.in.ImageUseCase;
 import com.ogd.stockdiary.domain.investmentprinciple.entity.InvestmentPrinciple;
 import com.ogd.stockdiary.domain.investmentprinciple.port.out.InvestmentPrincipleRepository;
 import com.ogd.stockdiary.domain.principlecheck.dto.PrincipleCheckCommand;
@@ -43,6 +46,7 @@ public class RetrospectionService implements CreateRetrospectionUseCase, GetRetr
     private final JpaImageMetadataRepository imageMetadataRepository;
     private final JpaPrincipleCheckImageRepository principleCheckImageRepository;
     private final JpaPrincipleCheckLinkRepository principleCheckLinkRepository;
+    private final ImageUseCase imageUseCase;
 
     @Override
     @Transactional
@@ -136,6 +140,36 @@ public class RetrospectionService implements CreateRetrospectionUseCase, GetRetr
         Retrospection retrospection = retrospectionRepository.findByIdAndUserId(retrospectionId, userId);
         List<PrincipleCheck> principleChecks = principleCheckRepository.findByRetrospectionId(retrospectionId);
 
-        return RetrospectionMapper.toGetResponse(retrospection, principleChecks);
+        // PrincipleCheck ID별로 이미지 URL 목록 생성
+        Map<Long, List<String>> imageUrlsMap = principleChecks.stream()
+            .collect(Collectors.toMap(
+                PrincipleCheck::getId,
+                pc -> getImageUrls(pc.getId())));
+
+        // PrincipleCheck ID별로 링크 목록 생성
+        Map<Long, List<String>> linksMap = principleChecks.stream()
+            .collect(Collectors.toMap(
+                PrincipleCheck::getId,
+                pc -> getLinks(pc.getId())));
+
+        return RetrospectionMapper.toGetResponse(retrospection, principleChecks, imageUrlsMap, linksMap);
+    }
+
+    private List<String> getImageUrls(Long principleCheckId) {
+        List<PrincipleCheckImage> principleCheckImages = principleCheckImageRepository
+            .findByPrincipleCheckId(principleCheckId);
+
+        return principleCheckImages.stream()
+            .map(pci -> imageUseCase.getDownloadUrl(pci.getImage().getObjectKey()))
+            .toList();
+    }
+
+    private List<String> getLinks(Long principleCheckId) {
+        List<PrincipleCheckLink> principleCheckLinks = principleCheckLinkRepository
+            .findByPrincipleCheckId(principleCheckId);
+
+        return principleCheckLinks.stream()
+            .map(PrincipleCheckLink::getLinkUrl)
+            .toList();
     }
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/service/RetrospectionService.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/service/RetrospectionService.java
@@ -6,14 +6,21 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
 
+import com.ogd.stockdiary.application.image.repository.JpaImageMetadataRepository;
+import com.ogd.stockdiary.application.image.repository.JpaPrincipleCheckImageRepository;
+import com.ogd.stockdiary.application.principlecheck.repository.JpaPrincipleCheckLinkRepository;
 import com.ogd.stockdiary.application.retrospection.dto.mapper.RetrospectionMapper;
 import com.ogd.stockdiary.application.retrospection.dto.response.GetRetrospectionResponse;
 import com.ogd.stockdiary.application.user.repository.UserRepository;
 import com.ogd.stockdiary.common.httpresponse.CodeEnum;
+import com.ogd.stockdiary.domain.image.entity.ImageMetadata;
+import com.ogd.stockdiary.domain.image.entity.ImageStatus;
+import com.ogd.stockdiary.domain.image.entity.PrincipleCheckImage;
 import com.ogd.stockdiary.domain.investmentprinciple.entity.InvestmentPrinciple;
 import com.ogd.stockdiary.domain.investmentprinciple.port.out.InvestmentPrincipleRepository;
 import com.ogd.stockdiary.domain.principlecheck.dto.PrincipleCheckCommand;
 import com.ogd.stockdiary.domain.principlecheck.entity.PrincipleCheck;
+import com.ogd.stockdiary.domain.principlecheck.entity.PrincipleCheckLink;
 import com.ogd.stockdiary.domain.principlecheck.port.out.PrincipleCheckRepository;
 import com.ogd.stockdiary.domain.retrospection.entity.Retrospection;
 import com.ogd.stockdiary.domain.retrospection.port.in.CreateRetrospectionCommand;
@@ -33,6 +40,9 @@ public class RetrospectionService implements CreateRetrospectionUseCase, GetRetr
     private final UserRepository userRepository;
     private final PrincipleCheckRepository principleCheckRepository;
     private final InvestmentPrincipleRepository investmentPrincipleRepository;
+    private final JpaImageMetadataRepository imageMetadataRepository;
+    private final JpaPrincipleCheckImageRepository principleCheckImageRepository;
+    private final JpaPrincipleCheckLinkRepository principleCheckLinkRepository;
 
     @Override
     @Transactional
@@ -63,18 +73,61 @@ public class RetrospectionService implements CreateRetrospectionUseCase, GetRetr
         Retrospection retrospection,
         List<PrincipleCheckCommand> principleCheckCommands,
         Long userId) {
-        List<PrincipleCheck> principleChecks = principleCheckCommands.stream()
-            .map(command -> {
-                InvestmentPrinciple principle = investmentPrincipleRepository
-                    .findByIdAndUserId(command.getPrincipleId(), userId)
-                    .orElseThrow(() -> new ApplicationException(CodeEnum.FRS_003,
-                        "투자원칙을 찾을 수 없습니다: " + command.getPrincipleId()));
+        principleCheckCommands.forEach(command -> {
+            // 투자원칙 조회
+            InvestmentPrinciple principle = investmentPrincipleRepository
+                .findByIdAndUserId(command.getPrincipleId(), userId)
+                .orElseThrow(() -> new ApplicationException(CodeEnum.FRS_003,
+                    "투자원칙을 찾을 수 없습니다: " + command.getPrincipleId()));
 
-                return PrincipleCheck.create(retrospection, principle, command.getStatus());
-            })
+            // PrincipleCheck 생성 및 저장
+            PrincipleCheck principleCheck = PrincipleCheck.create(
+                retrospection, principle, command.getStatus(), command.getReason());
+            PrincipleCheck savedPrincipleCheck = principleCheckRepository.save(principleCheck);
+
+            // 이미지 처리
+            if (!CollectionUtils.isEmpty(command.getImageIds())) {
+                saveImages(savedPrincipleCheck, command.getImageIds(), userId);
+            }
+
+            // 링크 처리
+            if (!CollectionUtils.isEmpty(command.getLinks())) {
+                saveLinks(savedPrincipleCheck, command.getLinks());
+            }
+        });
+    }
+
+    private void saveImages(PrincipleCheck principleCheck, List<Long> imageIds, Long userId) {
+        List<ImageMetadata> images = imageMetadataRepository.findAllById(imageIds);
+
+        // 이미지 존재 여부 및 소유권 검증
+        if (images.size() != imageIds.size()) {
+            throw new ApplicationException(CodeEnum.FRS_003, "일부 이미지를 찾을 수 없습니다");
+        }
+
+        images.forEach(image -> {
+            if (!image.getUser().getId().equals(userId)) {
+                throw new ApplicationException(CodeEnum.FRS_003,
+                    "해당 이미지에 대한 권한이 없습니다: " + image.getId());
+            }
+        });
+
+        // PrincipleCheckImage 매핑 생성
+        List<PrincipleCheckImage> principleCheckImages = images.stream()
+            .map(image -> PrincipleCheckImage.create(principleCheck, image))
             .toList();
+        principleCheckImageRepository.saveAll(principleCheckImages);
 
-        principleCheckRepository.saveAll(principleChecks);
+        // 이미지 상태를 C(저장완료)로 변경
+        images.forEach(image -> image.updateStatus(ImageStatus.C));
+        imageMetadataRepository.saveAll(images);
+    }
+
+    private void saveLinks(PrincipleCheck principleCheck, List<String> links) {
+        List<PrincipleCheckLink> principleCheckLinks = links.stream()
+            .map(link -> PrincipleCheckLink.create(principleCheck, link))
+            .toList();
+        principleCheckLinkRepository.saveAll(principleCheckLinks);
     }
 
     @Override

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/image/port/in/ImageUseCase.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/image/port/in/ImageUseCase.java
@@ -13,4 +13,13 @@ public interface ImageUseCase {
      * @return 저장된 이미지 메타데이터
      */
     ImageMetadata uploadImage(UploadImageCommand command);
+
+    /**
+     * 이미지 다운로드 URL을 생성합니다.
+     *
+     * @param objectKey
+     *            객체 키 (파일 경로)
+     * @return Pre-Signed 다운로드 URL
+     */
+    String getDownloadUrl(String objectKey);
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlecheck/dto/PrincipleCheckCommand.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlecheck/dto/PrincipleCheckCommand.java
@@ -1,5 +1,7 @@
 package com.ogd.stockdiary.domain.principlecheck.dto;
 
+import java.util.List;
+
 import com.ogd.stockdiary.domain.principlecheck.entity.PrincipleCheckStatus;
 
 import lombok.Getter;
@@ -11,4 +13,7 @@ public class PrincipleCheckCommand {
 
     private final Long principleId;
     private final PrincipleCheckStatus status;
+    private final String reason;
+    private final List<Long> imageIds;
+    private final List<String> links;
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlecheck/entity/PrincipleCheck.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlecheck/entity/PrincipleCheck.java
@@ -44,6 +44,9 @@ public class PrincipleCheck {
     @Column(name = "status", nullable = false)
     private PrincipleCheckStatus status;
 
+    @Column(name = "reason", columnDefinition = "TEXT")
+    private String reason;
+
     @Column(updatable = false)
     private LocalDateTime createdAt;
 
@@ -61,11 +64,12 @@ public class PrincipleCheck {
     }
 
     public static PrincipleCheck create(
-        Retrospection retrospection, InvestmentPrinciple principle, PrincipleCheckStatus status) {
+        Retrospection retrospection, InvestmentPrinciple principle, PrincipleCheckStatus status, String reason) {
         PrincipleCheck principleCheck = new PrincipleCheck();
         principleCheck.retrospection = retrospection;
         principleCheck.principle = principle;
         principleCheck.status = status;
+        principleCheck.reason = reason;
         return principleCheck;
     }
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlecheck/entity/PrincipleCheckLink.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlecheck/entity/PrincipleCheckLink.java
@@ -1,0 +1,52 @@
+package com.ogd.stockdiary.domain.principlecheck.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "principle_check_links")
+@Getter
+@NoArgsConstructor
+public class PrincipleCheckLink {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "principle_check_id", nullable = false, foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
+    private PrincipleCheck principleCheck;
+
+    @Column(name = "link_url", nullable = false, length = 2048)
+    private String linkUrl;
+
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public static PrincipleCheckLink create(PrincipleCheck principleCheck, String linkUrl) {
+        PrincipleCheckLink principleCheckLink = new PrincipleCheckLink();
+        principleCheckLink.principleCheck = principleCheck;
+        principleCheckLink.linkUrl = linkUrl;
+        return principleCheckLink;
+    }
+}

--- a/stock-diary/src/main/resources/application.yml
+++ b/stock-diary/src/main/resources/application.yml
@@ -30,7 +30,7 @@ cloud:
 spring:
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: none
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
## 📌 관련 이슈
- Jira Ticket: [OGD-32](https://depromeet05.atlassian.net/browse/OGD-32)

## 🔍 PR의 이유
  - 투자원칙 체크 시 투자 이유, 관련 이미지, 참고 링크를 함께
   저장하고 조회할 수 있도록 기능 확장
  - MinIO 사용 시 발생하는 설정 및 URL 파싱 문제 해결

  ## ✨ 주요 변경사항
  - [x] 투자원칙 체크 엔티티에 이유(reason) 필드 추가
  - [x] 투자원칙 체크 링크 엔티티 및 리포지토리 추가
  - [x] 투자원칙 체크 생성 시 이유, 이미지(최대 3개),
  링크(최대 3개) 저장 기능 추가
  - [x] 회고 조회 API 응답에 투자 이유, 이미지 다운로드 URL,
  링크 포함
  - [x] MinIO Presigner에 path-style 설정 추가
  - [x] objectKey 생성 시 앞의 슬래시(/) 제거
  - [x] 파일 다운로드 URL API의 PathVariable을
  RequestParam으로 변경
  - [x] ImageUseCase에 다운로드 URL 생성 메서드 추가
  - [x] JPA DDL auto 설정을 none으로 변경

  ## 📎 참고(선택)
  - MinIO는 AWS S3와 달리 path-style URL을 필수로 사용하므로
  S3Presigner 설정 수정 필요
  - objectKey에 슬래시(/)가 포함될 경우 PathVariable 사용 시
  URL 파싱 오류 발생
  - 이미지 업로드 시 임시 상태(T)로 저장 후, 투자원칙 체크에
  연결되면 완료 상태(C)로 변경