### PR TITLE
[OGD-34] 투자원칙 조회 API response에 필드 추가

### DIFF
--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/dto/mapper/InvestmentPrincipleMapper.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/dto/mapper/InvestmentPrincipleMapper.java
@@ -58,8 +58,11 @@ public class InvestmentPrincipleMapper {
         Long groupId = principle.getPrincipleGroup() != null
             ? principle.getPrincipleGroup().getId()
             : null;
+        String groupName = principle.getPrincipleGroup() != null
+            ? principle.getPrincipleGroup().getGroupName()
+            : null;
         return new InvestmentPrincipleResponse(
-            principle.getId(), groupId, principle.getPrinciple(), principle.getDisplayOrder());
+            principle.getId(), groupId, groupName, principle.getPrinciple(), principle.getDisplayOrder());
     }
 
     public static List<InvestmentPrincipleResponse> toResponseList(

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/dto/response/InvestmentPrincipleResponse.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/dto/response/InvestmentPrincipleResponse.java
@@ -9,6 +9,7 @@ public class InvestmentPrincipleResponse {
 
     private final Long id;
     private final Long groupId;
+    private final String groupName;
     private final String principle;
     private final Integer displayOrder;
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/repository/JpaInvestmentPrincipleRepository.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/repository/JpaInvestmentPrincipleRepository.java
@@ -14,7 +14,8 @@ import com.ogd.stockdiary.domain.investmentprinciple.entity.InvestmentPrinciple;
 @Repository
 public interface JpaInvestmentPrincipleRepository extends JpaRepository<InvestmentPrinciple, Long> {
 
-    List<InvestmentPrinciple> findByUserId(Long userId);
+    @Query("SELECT ip FROM InvestmentPrinciple ip LEFT JOIN FETCH ip.principleGroup WHERE ip.user.id = :userId")
+    List<InvestmentPrinciple> findByUserId(@Param("userId") Long userId);
 
     Optional<InvestmentPrinciple> findByIdAndUserId(Long id, Long userId);
 

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/principlegroup/dto/mapper/PrincipleGroupMapper.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/principlegroup/dto/mapper/PrincipleGroupMapper.java
@@ -5,6 +5,7 @@ import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Component;
 
+import com.ogd.stockdiary.application.investmentprinciple.dto.mapper.InvestmentPrincipleMapper;
 import com.ogd.stockdiary.application.investmentprinciple.dto.response.InvestmentPrincipleResponse;
 import com.ogd.stockdiary.application.principlegroup.dto.request.CreatePrincipleGroupRequest;
 import com.ogd.stockdiary.application.principlegroup.dto.request.ReorderPrincipleGroupsRequest;
@@ -43,17 +44,7 @@ public class PrincipleGroupMapper {
     public PrincipleGroupResponse toResponse(
         PrincipleGroup principleGroup, List<InvestmentPrinciple> principles) {
         List<InvestmentPrincipleResponse> principleResponses = principles.stream()
-            .map(
-                p -> {
-                    Long groupId = p.getPrincipleGroup() != null
-                        ? p.getPrincipleGroup().getId()
-                        : null;
-                    return new InvestmentPrincipleResponse(
-                        p.getId(),
-                        groupId,
-                        p.getPrinciple(),
-                        p.getDisplayOrder());
-                })
+            .map(InvestmentPrincipleMapper::toResponse)
             .collect(Collectors.toList());
 
         return new PrincipleGroupResponse(


### PR DESCRIPTION
## 📌 관련 이슈
- Jira Ticket: [OGD-34](https://depromeet05.atlassian.net/browse/OGD-34)

  ## 🔍 PR의 이유
  - 투자원칙 조회 API 응답에 그룹명(groupName) 필드 추가 요청 사항 반영
  - 기존 구현에서는 groupId만 제공되어 별도의 API 호출 없이는 그룹명을 알 수 없었음
  - N+1 쿼리 문제로 인한 성능 저하 발생 가능

  ## ✨ 주요 변경사항
  - [x] InvestmentPrincipleResponse에 groupName 필드 추가
  - [x] InvestmentPrincipleMapper의 toResponse 메서드에 groupName
  매핑 로직 추가
  - [x] PrincipleGroupMapper의 toResponse 메서드에 groupName 매핑
  로직 추가
  - [x] JpaInvestmentPrincipleRepository의 findByUserId 메서드에 LEFT
   JOIN FETCH 추가하여 N+1 쿼리 문제 해결

  ## 📎 참고(선택)
  - principleGroup이 null인 경우 groupName도 null로 반환됩니다
  - Fetch join을 통해 투자원칙 조회 시 PrincipleGroup을 한 번의
  쿼리로 함께 조회하여 성능 최적화