### PR TITLE
[OGD-35] 투자원칙에 매수/매도 구분 추가

### DIFF
--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/controller/InvestmentPrincipleController.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/controller/InvestmentPrincipleController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.ogd.stockdiary.application.investmentprinciple.dto.mapper.InvestmentPrincipleMapper;
@@ -30,6 +31,7 @@ import com.ogd.stockdiary.domain.investmentprinciple.dto.CreatePrincipleCommand;
 import com.ogd.stockdiary.domain.investmentprinciple.dto.ReorderPrinciplesCommand;
 import com.ogd.stockdiary.domain.investmentprinciple.dto.UpdatePrincipleCommand;
 import com.ogd.stockdiary.domain.investmentprinciple.entity.InvestmentPrinciple;
+import com.ogd.stockdiary.domain.investmentprinciple.entity.PrincipleType;
 import com.ogd.stockdiary.domain.investmentprinciple.usecase.InvestmentPrincipleUseCase;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -45,13 +47,14 @@ public class InvestmentPrincipleController {
     private final InvestmentPrincipleUseCase investmentPrincipleUseCase;
 
     @GetMapping
-    @Operation(summary = "투자원칙 목록 조회", description = "사용자의 모든 투자원칙을 조회합니다.")
-    public HttpApiResponse<List<InvestmentPrincipleResponse>> getUserPrinciples() {
+    @Operation(summary = "투자원칙 목록 조회", description = "사용자의 투자원칙을 조회합니다. type 파라미터로 BUY(매수) 또는 SELL(매도)를 지정할 수 있으며, 지정하지 않으면 전체 조회합니다.")
+    public HttpApiResponse<List<InvestmentPrincipleResponse>> getUserPrinciples(
+        @RequestParam(required = false) PrincipleType type) {
 
         // TODO: Spring Security에서 User 정보 가져오기
         Long userId = 1L; // 임시로 하드코딩
 
-        List<InvestmentPrinciple> principles = investmentPrincipleUseCase.getUserPrinciples(userId);
+        List<InvestmentPrinciple> principles = investmentPrincipleUseCase.getUserPrinciples(userId, type);
         List<InvestmentPrincipleResponse> responses = InvestmentPrincipleMapper.toResponseList(principles);
 
         return HttpApiResponse.of(responses);

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/dto/mapper/InvestmentPrincipleMapper.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/dto/mapper/InvestmentPrincipleMapper.java
@@ -22,12 +22,13 @@ public class InvestmentPrincipleMapper {
 
     public static CreatePrincipleCommand toCommand(CreatePrincipleRequest request, Long userId) {
         return new CreatePrincipleCommand(
-            userId, request.getGroupId(), request.getPrinciple(), request.getDisplayOrder());
+            userId, request.getGroupId(), request.getPrincipleType(), request.getPrinciple(),
+            request.getDisplayOrder());
     }
 
     public static CreateMultiplePrinciplesCommand toCommand(
         CreateMultiplePrinciplesRequest request, Long userId) {
-        return new CreateMultiplePrinciplesCommand(userId, request.getPrinciples());
+        return new CreateMultiplePrinciplesCommand(userId, request.getPrincipleType(), request.getPrinciples());
     }
 
     public static UpdatePrincipleCommand toCommand(
@@ -49,6 +50,7 @@ public class InvestmentPrincipleMapper {
 
         return new BatchProcessCommand(
             userId,
+            request.getPrincipleType(),
             request.getCreatePrinciples(),
             updateCommands,
             request.getDeletePrincipleIds());
@@ -62,7 +64,8 @@ public class InvestmentPrincipleMapper {
             ? principle.getPrincipleGroup().getGroupName()
             : null;
         return new InvestmentPrincipleResponse(
-            principle.getId(), groupId, groupName, principle.getPrinciple(), principle.getDisplayOrder());
+            principle.getId(), groupId, groupName, principle.getPrincipleType(), principle.getPrinciple(),
+            principle.getDisplayOrder());
     }
 
     public static List<InvestmentPrincipleResponse> toResponseList(

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/dto/request/BatchProcessRequest.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/dto/request/BatchProcessRequest.java
@@ -2,6 +2,8 @@ package com.ogd.stockdiary.application.investmentprinciple.dto.request;
 
 import java.util.List;
 
+import com.ogd.stockdiary.domain.investmentprinciple.entity.PrincipleType;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,6 +12,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Schema(description = "투자원칙 일괄 처리 요청 정보")
 public class BatchProcessRequest {
+
+    @Schema(description = "생성할 투자원칙의 타입 (BUY: 매수, SELL: 매도)", example = "BUY", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private PrincipleType principleType;
 
     @Schema(description = "생성할 투자원칙 목록", example = "[\"손절매는 반드시 10% 이내에서\", \"분산투자로 위험 관리\"]", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private List<String> createPrinciples;

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/dto/request/CreateMultiplePrinciplesRequest.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/dto/request/CreateMultiplePrinciplesRequest.java
@@ -5,6 +5,8 @@ import java.util.List;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
+import com.ogd.stockdiary.domain.investmentprinciple.entity.PrincipleType;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,6 +15,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Schema(description = "다중 투자원칙 생성 요청 정보")
 public class CreateMultiplePrinciplesRequest {
+
+    @Schema(description = "투자원칙 타입 (BUY: 매수, SELL: 매도)", example = "BUY", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotNull(message = "투자원칙 타입은 필수입니다.")
+    private PrincipleType principleType;
 
     @Schema(description = "투자원칙 목록", example = "[\"손절매는 반드시 10% 이내에서\", \"매수 전 기업 재무제표 분석 필수\", \"분산투자로 위험 관리\"]", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotNull(message = "투자원칙 목록은 필수입니다.")

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/dto/request/CreatePrincipleRequest.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/dto/request/CreatePrincipleRequest.java
@@ -1,6 +1,9 @@
 package com.ogd.stockdiary.application.investmentprinciple.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import com.ogd.stockdiary.domain.investmentprinciple.entity.PrincipleType;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
@@ -13,6 +16,10 @@ public class CreatePrincipleRequest {
 
     @Schema(description = "투자원칙 그룹 ID (선택사항)", example = "1")
     private Long groupId;
+
+    @Schema(description = "투자원칙 타입 (BUY: 매수, SELL: 매도)", example = "BUY", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotNull(message = "투자원칙 타입은 필수입니다.")
+    private PrincipleType principleType;
 
     @Schema(description = "투자원칙 내용", example = "손절매는 반드시 10% 이내에서", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotBlank(message = "투자원칙 내용은 필수입니다.")

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/dto/response/InvestmentPrincipleResponse.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/dto/response/InvestmentPrincipleResponse.java
@@ -1,5 +1,7 @@
 package com.ogd.stockdiary.application.investmentprinciple.dto.response;
 
+import com.ogd.stockdiary.domain.investmentprinciple.entity.PrincipleType;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -10,6 +12,7 @@ public class InvestmentPrincipleResponse {
     private final Long id;
     private final Long groupId;
     private final String groupName;
+    private final PrincipleType principleType;
     private final String principle;
     private final Integer displayOrder;
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/repository/InvestmentPrincipleRepositoryImpl.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/repository/InvestmentPrincipleRepositoryImpl.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import org.springframework.stereotype.Repository;
 
 import com.ogd.stockdiary.domain.investmentprinciple.entity.InvestmentPrinciple;
+import com.ogd.stockdiary.domain.investmentprinciple.entity.PrincipleType;
 import com.ogd.stockdiary.domain.investmentprinciple.port.out.InvestmentPrincipleRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -19,6 +20,11 @@ public class InvestmentPrincipleRepositoryImpl implements InvestmentPrincipleRep
     @Override
     public List<InvestmentPrinciple> findByUserId(Long userId) {
         return jpaInvestmentPrincipleRepository.findByUserId(userId);
+    }
+
+    @Override
+    public List<InvestmentPrinciple> findByUserIdAndPrincipleType(Long userId, PrincipleType principleType) {
+        return jpaInvestmentPrincipleRepository.findByUserIdAndPrincipleType(userId, principleType);
     }
 
     @Override

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/repository/JpaInvestmentPrincipleRepository.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/repository/JpaInvestmentPrincipleRepository.java
@@ -10,12 +10,17 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.ogd.stockdiary.domain.investmentprinciple.entity.InvestmentPrinciple;
+import com.ogd.stockdiary.domain.investmentprinciple.entity.PrincipleType;
 
 @Repository
 public interface JpaInvestmentPrincipleRepository extends JpaRepository<InvestmentPrinciple, Long> {
 
     @Query("SELECT ip FROM InvestmentPrinciple ip LEFT JOIN FETCH ip.principleGroup WHERE ip.user.id = :userId")
     List<InvestmentPrinciple> findByUserId(@Param("userId") Long userId);
+
+    @Query("SELECT ip FROM InvestmentPrinciple ip LEFT JOIN FETCH ip.principleGroup WHERE ip.user.id = :userId AND ip.principleType = :principleType")
+    List<InvestmentPrinciple> findByUserIdAndPrincipleType(@Param("userId") Long userId,
+        @Param("principleType") PrincipleType principleType);
 
     Optional<InvestmentPrinciple> findByIdAndUserId(Long id, Long userId);
 

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/principlegroup/dto/mapper/PrincipleGroupMapper.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/principlegroup/dto/mapper/PrincipleGroupMapper.java
@@ -22,7 +22,8 @@ public class PrincipleGroupMapper {
 
     public CreatePrincipleGroupCommand toCommand(CreatePrincipleGroupRequest request, Long userId) {
         return new CreatePrincipleGroupCommand(
-            userId, request.getGroupName(), request.getDisplayOrder(), request.getPrinciples());
+            userId, request.getGroupName(), request.getDisplayOrder(), request.getPrincipleType(),
+            request.getPrinciples());
     }
 
     public UpdatePrincipleGroupCommand toCommand(

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/principlegroup/dto/request/CreatePrincipleGroupRequest.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/principlegroup/dto/request/CreatePrincipleGroupRequest.java
@@ -3,7 +3,10 @@ package com.ogd.stockdiary.application.principlegroup.dto.request;
 import java.util.List;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+
+import com.ogd.stockdiary.domain.investmentprinciple.entity.PrincipleType;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
@@ -22,6 +25,10 @@ public class CreatePrincipleGroupRequest {
 
     @Schema(description = "그룹 표시 순서", example = "1")
     private Integer displayOrder;
+
+    @Schema(description = "투자원칙 타입 (BUY: 매수, SELL: 매도)", example = "BUY", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotNull(message = "투자원칙 타입은 필수입니다.")
+    private PrincipleType principleType;
 
     @Schema(description = "그룹에 포함할 투자원칙 목록 (선택사항, 최대 5개)", example = "[\"안전마진을 확보하라\", \"기업의 본질 가치보다 낮게 거래되는 주식을 찾기\"]")
     @Size(max = 5, message = "그룹당 최대 5개의 투자원칙만 추가할 수 있습니다")

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/investmentprinciple/dto/BatchProcessCommand.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/investmentprinciple/dto/BatchProcessCommand.java
@@ -2,6 +2,8 @@ package com.ogd.stockdiary.domain.investmentprinciple.dto;
 
 import java.util.List;
 
+import com.ogd.stockdiary.domain.investmentprinciple.entity.PrincipleType;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -10,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 public class BatchProcessCommand {
 
     private final Long userId;
+    private final PrincipleType principleType;
     private final List<String> createPrinciples;
     private final List<UpdatePrincipleCommand> updatePrinciples;
     private final List<Long> deletePrincipleIds;

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/investmentprinciple/dto/CreateMultiplePrinciplesCommand.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/investmentprinciple/dto/CreateMultiplePrinciplesCommand.java
@@ -2,6 +2,8 @@ package com.ogd.stockdiary.domain.investmentprinciple.dto;
 
 import java.util.List;
 
+import com.ogd.stockdiary.domain.investmentprinciple.entity.PrincipleType;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -10,5 +12,6 @@ import lombok.RequiredArgsConstructor;
 public class CreateMultiplePrinciplesCommand {
 
     private final Long userId;
+    private final PrincipleType principleType;
     private final List<String> principles;
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/investmentprinciple/dto/CreatePrincipleCommand.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/investmentprinciple/dto/CreatePrincipleCommand.java
@@ -1,5 +1,7 @@
 package com.ogd.stockdiary.domain.investmentprinciple.dto;
 
+import com.ogd.stockdiary.domain.investmentprinciple.entity.PrincipleType;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -9,6 +11,7 @@ public class CreatePrincipleCommand {
 
     private final Long userId;
     private final Long groupId;
+    private final PrincipleType principleType;
     private final String principle;
     private final Integer displayOrder;
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/investmentprinciple/entity/InvestmentPrinciple.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/investmentprinciple/entity/InvestmentPrinciple.java
@@ -4,6 +4,8 @@ import java.time.LocalDateTime;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -40,6 +42,10 @@ public class InvestmentPrinciple {
     @JoinColumn(name = "group_id")
     private PrincipleGroup principleGroup;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "principle_type", nullable = false)
+    private PrincipleType principleType;
+
     private String principle;
 
     @Column(name = "display_order")
@@ -61,18 +67,20 @@ public class InvestmentPrinciple {
         this.updatedAt = LocalDateTime.now();
     }
 
-    public static InvestmentPrinciple create(User user, String principle) {
+    public static InvestmentPrinciple create(User user, PrincipleType principleType, String principle) {
         InvestmentPrinciple investmentPrinciple = new InvestmentPrinciple();
         investmentPrinciple.user = user;
+        investmentPrinciple.principleType = principleType;
         investmentPrinciple.principle = principle;
         return investmentPrinciple;
     }
 
     public static InvestmentPrinciple create(
-        User user, PrincipleGroup principleGroup, String principle, Integer displayOrder) {
+        User user, PrincipleGroup principleGroup, PrincipleType principleType, String principle, Integer displayOrder) {
         InvestmentPrinciple investmentPrinciple = new InvestmentPrinciple();
         investmentPrinciple.user = user;
         investmentPrinciple.principleGroup = principleGroup;
+        investmentPrinciple.principleType = principleType;
         investmentPrinciple.principle = principle;
         investmentPrinciple.displayOrder = displayOrder;
         return investmentPrinciple;

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/investmentprinciple/entity/PrincipleType.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/investmentprinciple/entity/PrincipleType.java
@@ -1,0 +1,6 @@
+package com.ogd.stockdiary.domain.investmentprinciple.entity;
+
+public enum PrincipleType {
+    BUY, // 매수 투자원칙
+    SELL // 매도 투자원칙
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/investmentprinciple/port/out/InvestmentPrincipleRepository.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/investmentprinciple/port/out/InvestmentPrincipleRepository.java
@@ -4,10 +4,13 @@ import java.util.List;
 import java.util.Optional;
 
 import com.ogd.stockdiary.domain.investmentprinciple.entity.InvestmentPrinciple;
+import com.ogd.stockdiary.domain.investmentprinciple.entity.PrincipleType;
 
 public interface InvestmentPrincipleRepository {
 
     List<InvestmentPrinciple> findByUserId(Long userId);
+
+    List<InvestmentPrinciple> findByUserIdAndPrincipleType(Long userId, PrincipleType principleType);
 
     InvestmentPrinciple save(InvestmentPrinciple investmentPrinciple);
 

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/investmentprinciple/service/InvestmentPrincipleService.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/investmentprinciple/service/InvestmentPrincipleService.java
@@ -16,6 +16,7 @@ import com.ogd.stockdiary.domain.investmentprinciple.dto.CreatePrincipleCommand;
 import com.ogd.stockdiary.domain.investmentprinciple.dto.ReorderPrinciplesCommand;
 import com.ogd.stockdiary.domain.investmentprinciple.dto.UpdatePrincipleCommand;
 import com.ogd.stockdiary.domain.investmentprinciple.entity.InvestmentPrinciple;
+import com.ogd.stockdiary.domain.investmentprinciple.entity.PrincipleType;
 import com.ogd.stockdiary.domain.investmentprinciple.port.out.InvestmentPrincipleRepository;
 import com.ogd.stockdiary.domain.investmentprinciple.usecase.InvestmentPrincipleUseCase;
 import com.ogd.stockdiary.domain.principlegroup.entity.PrincipleGroup;
@@ -36,7 +37,10 @@ public class InvestmentPrincipleService implements InvestmentPrincipleUseCase {
 
     @Override
     @Transactional(readOnly = true)
-    public List<InvestmentPrinciple> getUserPrinciples(Long userId) {
+    public List<InvestmentPrinciple> getUserPrinciples(Long userId, PrincipleType type) {
+        if (type != null) {
+            return investmentPrincipleRepository.findByUserIdAndPrincipleType(userId, type);
+        }
         return investmentPrincipleRepository.findByUserId(userId);
     }
 
@@ -71,11 +75,12 @@ public class InvestmentPrincipleService implements InvestmentPrincipleUseCase {
             principle = InvestmentPrinciple.create(
                 user,
                 principleGroup,
+                command.getPrincipleType(),
                 command.getPrinciple(),
                 command.getDisplayOrder());
         } else {
             // 그룹이 없는 경우
-            principle = InvestmentPrinciple.create(user, command.getPrinciple());
+            principle = InvestmentPrinciple.create(user, command.getPrincipleType(), command.getPrinciple());
         }
 
         return investmentPrincipleRepository.save(principle);
@@ -92,7 +97,7 @@ public class InvestmentPrincipleService implements InvestmentPrincipleUseCase {
                     "사용자를 찾을 수 없습니다: " + command.getUserId()));
 
         List<InvestmentPrinciple> principles = command.getPrinciples().stream()
-            .map(principleText -> InvestmentPrinciple.create(user, principleText))
+            .map(principleText -> InvestmentPrinciple.create(user, command.getPrincipleType(), principleText))
             .collect(Collectors.toList());
 
         return investmentPrincipleRepository.saveAll(principles);
@@ -137,7 +142,7 @@ public class InvestmentPrincipleService implements InvestmentPrincipleUseCase {
                         "사용자를 찾을 수 없습니다: " + command.getUserId()));
 
             List<InvestmentPrinciple> principles = command.getCreatePrinciples().stream()
-                .map(principleText -> InvestmentPrinciple.create(user, principleText))
+                .map(principleText -> InvestmentPrinciple.create(user, command.getPrincipleType(), principleText))
                 .collect(Collectors.toList());
             createdPrinciples = investmentPrincipleRepository.saveAll(principles);
         }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/investmentprinciple/usecase/InvestmentPrincipleUseCase.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/investmentprinciple/usecase/InvestmentPrincipleUseCase.java
@@ -9,10 +9,11 @@ import com.ogd.stockdiary.domain.investmentprinciple.dto.CreatePrincipleCommand;
 import com.ogd.stockdiary.domain.investmentprinciple.dto.ReorderPrinciplesCommand;
 import com.ogd.stockdiary.domain.investmentprinciple.dto.UpdatePrincipleCommand;
 import com.ogd.stockdiary.domain.investmentprinciple.entity.InvestmentPrinciple;
+import com.ogd.stockdiary.domain.investmentprinciple.entity.PrincipleType;
 
 public interface InvestmentPrincipleUseCase {
 
-    List<InvestmentPrinciple> getUserPrinciples(Long userId);
+    List<InvestmentPrinciple> getUserPrinciples(Long userId, PrincipleType type);
 
     InvestmentPrinciple createPrinciple(CreatePrincipleCommand command);
 

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlegroup/dto/CreatePrincipleGroupCommand.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlegroup/dto/CreatePrincipleGroupCommand.java
@@ -2,6 +2,8 @@ package com.ogd.stockdiary.domain.principlegroup.dto;
 
 import java.util.List;
 
+import com.ogd.stockdiary.domain.investmentprinciple.entity.PrincipleType;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -12,5 +14,6 @@ public class CreatePrincipleGroupCommand {
     private Long userId;
     private String groupName;
     private Integer displayOrder;
+    private PrincipleType principleType;
     private List<String> principles; // optional
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlegroup/service/PrincipleGroupService.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlegroup/service/PrincipleGroupService.java
@@ -75,6 +75,7 @@ public class PrincipleGroupService implements PrincipleGroupUseCase {
                     index -> InvestmentPrinciple.create(
                         user,
                         savedGroup,
+                        command.getPrincipleType(),
                         command.getPrinciples().get(index),
                         index))
                 .collect(Collectors.toList());


### PR DESCRIPTION
## 📌 관련 이슈
- Jira Ticket: [OGD-35](https://depromeet05.atlassian.net/browse/OGD-35)

 ## 🔍 PR의 이유
  - 투자원칙을 매수용과 매도용으로 구분하여 관리할 필요성 발생
  - 사용자가 매수 시점과 매도 시점에 따른 투자원칙을 별도로 작성하고 조회할 수 있어야 함

  ## ✨ 주요 변경사항
  - [x] `PrincipleType` enum 추가 (BUY: 매수, SELL: 매도)
  - [x] `InvestmentPrinciple` entity에 `principleType` 필드 추가 (NOT
   NULL)
  - [x] 투자원칙 생성 API에 `principleType` 필수 파라미터 추가
  - [x] 투자원칙 조회 API에 타입별 필터링 기능 추가
    - `GET /api/v1/investment-principles?type=BUY` - 매수 원칙만 조회
    - `GET /api/v1/investment-principles?type=SELL` - 매도 원칙만
  조회
    - `GET /api/v1/investment-principles` - 전체 조회
  - [x] 투자원칙 그룹 생성 시 `principleType` 지원 추가
  - [x] 관련 DTO, Command, Repository, Service, Mapper 전체 수정
  - [x] 타입 변경 불가 정책 적용 (생성 시에만 타입 지정 가능, 수정 시
   변경 불가)

  ## 📎 참고