### PR TITLE
[OGD-39] 투자원칙에 '설명' 컬럼 추가

### DIFF
--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/controller/InvestmentPrincipleController.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/controller/InvestmentPrincipleController.java
@@ -4,16 +4,7 @@ import java.util.List;
 
 import jakarta.validation.Valid;
 
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import com.ogd.stockdiary.application.investmentprinciple.dto.mapper.InvestmentPrincipleMapper;
 import com.ogd.stockdiary.application.investmentprinciple.dto.request.CreateMultiplePrinciplesRequest;
@@ -86,7 +77,7 @@ public class InvestmentPrincipleController {
         return HttpApiResponse.of(responses);
     }
 
-    @PutMapping("/{principleId}")
+    @PatchMapping("/{principleId}")
     @Operation(summary = "투자원칙 수정", description = "투자원칙의 내용을 수정합니다.")
     public HttpApiResponse<InvestmentPrincipleResponse> updatePrinciple(
         @PathVariable Long principleId, @Valid @RequestBody UpdatePrincipleRequest request) {

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/dto/mapper/InvestmentPrincipleMapper.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/dto/mapper/InvestmentPrincipleMapper.java
@@ -1,5 +1,7 @@
 package com.ogd.stockdiary.application.investmentprinciple.dto.mapper;
 
+import static com.ogd.stockdiary.domain.investmentprinciple.dto.CreateMultiplePrinciplesCommand.*;
+
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -18,18 +20,21 @@ public class InvestmentPrincipleMapper {
 
     public static CreatePrincipleCommand toCommand(CreatePrincipleRequest request, Long userId) {
         return new CreatePrincipleCommand(
-            userId, request.getGroupId(), request.getPrinciple(),
+            userId, request.getGroupId(), request.getPrinciple(), request.getDescription(),
             request.getDisplayOrder());
     }
 
     public static CreateMultiplePrinciplesCommand toCommand(
         CreateMultiplePrinciplesRequest request, Long userId) {
-        return new CreateMultiplePrinciplesCommand(userId, request.getGroupId(), request.getPrinciples());
+        List<PrincipleItem> commandItems = request.getPrinciples().stream()
+            .map(item -> new PrincipleItem(item.getPrinciple(), item.getDescription()))
+            .collect(Collectors.toList());
+        return new CreateMultiplePrinciplesCommand(userId, request.getGroupId(), commandItems);
     }
 
     public static UpdatePrincipleCommand toCommand(
         UpdatePrincipleRequest request, Long principleId, Long userId) {
-        return new UpdatePrincipleCommand(principleId, userId, request.getPrinciple());
+        return new UpdatePrincipleCommand(principleId, userId, request.getPrinciple(), request.getDescription());
     }
 
     public static InvestmentPrincipleResponse toResponse(InvestmentPrinciple principle) {
@@ -37,7 +42,7 @@ public class InvestmentPrincipleMapper {
         String groupName = principle.getPrincipleGroup().getGroupName();
         return new InvestmentPrincipleResponse(
             principle.getId(), groupId, groupName, principle.getPrincipleGroup().getPrincipleType(),
-            principle.getPrinciple(),
+            principle.getPrinciple(), principle.getDescription(),
             principle.getDisplayOrder());
     }
 

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/dto/request/CreateMultiplePrinciplesRequest.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/dto/request/CreateMultiplePrinciplesRequest.java
@@ -2,6 +2,8 @@ package com.ogd.stockdiary.application.investmentprinciple.dto.request;
 
 import java.util.List;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
@@ -18,8 +20,22 @@ public class CreateMultiplePrinciplesRequest {
     @NotNull(message = "투자원칙 그룹 ID는 필수입니다.")
     private Long groupId;
 
-    @Schema(description = "투자원칙 목록", example = "[\"손절매는 반드시 10% 이내에서\", \"매수 전 기업 재무제표 분석 필수\", \"분산투자로 위험 관리\"]", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(description = "투자원칙 목록", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotNull(message = "투자원칙 목록은 필수입니다.")
     @NotEmpty(message = "투자원칙은 최소 1개 이상이어야 합니다.")
-    private List<String> principles;
+    @Valid
+    private List<PrincipleItem> principles;
+
+    @Getter
+    @NoArgsConstructor
+    @Schema(description = "투자원칙 항목")
+    public static class PrincipleItem {
+
+        @Schema(description = "투자원칙 내용", example = "손절매는 반드시 10% 이내에서", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank(message = "투자원칙 내용은 필수입니다.")
+        private String principle;
+
+        @Schema(description = "투자원칙 설명", example = "손실을 최소화하기 위한 기본 규칙")
+        private String description;
+    }
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/dto/request/CreatePrincipleRequest.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/dto/request/CreatePrincipleRequest.java
@@ -20,6 +20,9 @@ public class CreatePrincipleRequest {
     @NotBlank(message = "투자원칙 내용은 필수입니다.")
     private String principle;
 
+    @Schema(description = "투자원칙 설명 (선택사항)", example = "손실을 최소화하기 위한 기본 규칙")
+    private String description;
+
     @Schema(description = "그룹 내 표시 순서 (선택사항)", example = "0")
     private Integer displayOrder;
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/dto/request/UpdatePrincipleRequest.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/dto/request/UpdatePrincipleRequest.java
@@ -14,4 +14,7 @@ public class UpdatePrincipleRequest {
     @Schema(description = "수정할 투자원칙 내용", example = "손절매는 반드시 5% 이내에서", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotBlank(message = "투자원칙 내용은 필수입니다.")
     private String principle;
+
+    @Schema(description = "투자원칙 설명 (선택사항)", example = "손실을 최소화하기 위한 기본 규칙")
+    private String description;
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/dto/response/InvestmentPrincipleResponse.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/investmentprinciple/dto/response/InvestmentPrincipleResponse.java
@@ -14,5 +14,6 @@ public class InvestmentPrincipleResponse {
     private final String groupName;
     private final PrincipleType principleType;
     private final String principle;
+    private final String description;
     private final Integer displayOrder;
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/principlegroup/controller/PrincipleGroupController.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/principlegroup/controller/PrincipleGroupController.java
@@ -53,7 +53,7 @@ public class PrincipleGroupController {
         List<PrincipleGroup> principleGroups = principleGroupUseCase.getUserPrincipleGroups(userId);
 
         List<PrincipleGroupResponse> responses = principleGroups.stream()
-            .sorted(Comparator.comparing(PrincipleGroup::getDisplayOrder))
+            .sorted(Comparator.comparing(PrincipleGroup::getId).reversed())
             .map(
                 group -> {
                     List<InvestmentPrinciple> principles = investmentPrincipleRepository.findByPrincipleGroupId(

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/principlegroup/dto/mapper/PrincipleGroupMapper.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/principlegroup/dto/mapper/PrincipleGroupMapper.java
@@ -21,9 +21,16 @@ import com.ogd.stockdiary.domain.principlegroup.entity.PrincipleGroup;
 public class PrincipleGroupMapper {
 
     public CreatePrincipleGroupCommand toCommand(CreatePrincipleGroupRequest request, Long userId) {
+        List<CreatePrincipleGroupCommand.PrincipleItem> commandItems = null;
+        if (request.getPrinciples() != null) {
+            commandItems = request.getPrinciples().stream()
+                .map(item -> new CreatePrincipleGroupCommand.PrincipleItem(
+                    item.getPrinciple(), item.getDescription()))
+                .collect(Collectors.toList());
+        }
         return new CreatePrincipleGroupCommand(
             userId, request.getGroupName(), request.getDisplayOrder(), request.getPrincipleType(),
-            request.getPrinciples());
+            commandItems);
     }
 
     public UpdatePrincipleGroupCommand toCommand(

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/principlegroup/dto/request/CreatePrincipleGroupRequest.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/principlegroup/dto/request/CreatePrincipleGroupRequest.java
@@ -2,6 +2,7 @@ package com.ogd.stockdiary.application.principlegroup.dto.request;
 
 import java.util.List;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -30,7 +31,22 @@ public class CreatePrincipleGroupRequest {
     @NotNull(message = "투자원칙 타입은 필수입니다.")
     private PrincipleType principleType;
 
-    @Schema(description = "그룹에 포함할 투자원칙 목록 (선택사항, 최대 5개)", example = "[\"안전마진을 확보하라\", \"기업의 본질 가치보다 낮게 거래되는 주식을 찾기\"]")
+    @Schema(description = "그룹에 포함할 투자원칙 목록 (선택사항, 최대 5개)")
     @Size(max = 5, message = "그룹당 최대 5개의 투자원칙만 추가할 수 있습니다")
-    private List<@NotBlank(message = "투자원칙 내용은 필수입니다") String> principles;
+    @Valid
+    private List<PrincipleItem> principles;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "투자원칙 항목")
+    public static class PrincipleItem {
+
+        @Schema(description = "투자원칙 내용", example = "안전마진을 확보하라", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank(message = "투자원칙 내용은 필수입니다")
+        private String principle;
+
+        @Schema(description = "투자원칙 설명", example = "충분한 여유를 두고 투자하기")
+        private String description;
+    }
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/investmentprinciple/dto/CreateMultiplePrinciplesCommand.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/investmentprinciple/dto/CreateMultiplePrinciplesCommand.java
@@ -11,5 +11,12 @@ public class CreateMultiplePrinciplesCommand {
 
     private final Long userId;
     private final Long groupId;
-    private final List<String> principles;
+    private final List<PrincipleItem> principles;
+
+    @Getter
+    @RequiredArgsConstructor
+    public static class PrincipleItem {
+        private final String principle;
+        private final String description;
+    }
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/investmentprinciple/dto/CreatePrincipleCommand.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/investmentprinciple/dto/CreatePrincipleCommand.java
@@ -10,5 +10,6 @@ public class CreatePrincipleCommand {
     private final Long userId;
     private final Long groupId;
     private final String principle;
+    private final String description;
     private final Integer displayOrder;
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/investmentprinciple/dto/UpdatePrincipleCommand.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/investmentprinciple/dto/UpdatePrincipleCommand.java
@@ -10,4 +10,5 @@ public class UpdatePrincipleCommand {
     private final Long principleId;
     private final Long userId;
     private final String principle;
+    private final String description;
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/investmentprinciple/entity/InvestmentPrinciple.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/investmentprinciple/entity/InvestmentPrinciple.java
@@ -74,8 +74,9 @@ public class InvestmentPrinciple {
         return investmentPrinciple;
     }
 
-    public void updatePrinciple(String principle) {
+    public void updatePrinciple(String principle, String description) {
         this.principle = principle;
+        this.description = description;
     }
 
     public void updateDisplayOrder(Integer displayOrder) {

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/investmentprinciple/entity/InvestmentPrinciple.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/investmentprinciple/entity/InvestmentPrinciple.java
@@ -42,6 +42,8 @@ public class InvestmentPrinciple {
 
     private String principle;
 
+    private String description;
+
     @Column(name = "display_order")
     private Integer displayOrder;
 
@@ -62,11 +64,12 @@ public class InvestmentPrinciple {
     }
 
     public static InvestmentPrinciple create(
-        User user, PrincipleGroup principleGroup, String principle, Integer displayOrder) {
+        User user, PrincipleGroup principleGroup, String principle, String description, Integer displayOrder) {
         InvestmentPrinciple investmentPrinciple = new InvestmentPrinciple();
         investmentPrinciple.user = user;
         investmentPrinciple.principleGroup = principleGroup;
         investmentPrinciple.principle = principle;
+        investmentPrinciple.description = description;
         investmentPrinciple.displayOrder = displayOrder;
         return investmentPrinciple;
     }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/investmentprinciple/service/InvestmentPrincipleService.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/investmentprinciple/service/InvestmentPrincipleService.java
@@ -71,6 +71,7 @@ public class InvestmentPrincipleService implements InvestmentPrincipleUseCase {
             user,
             principleGroup,
             command.getPrinciple(),
+            command.getDescription(),
             command.getDisplayOrder());
 
         return investmentPrincipleRepository.save(principle);
@@ -105,11 +106,12 @@ public class InvestmentPrincipleService implements InvestmentPrincipleUseCase {
 
         List<InvestmentPrinciple> principles = new ArrayList<>();
         for (int i = 0; i < command.getPrinciples().size(); i++) {
-            String principleText = command.getPrinciples().get(i);
+            CreateMultiplePrinciplesCommand.PrincipleItem item = command.getPrinciples().get(i);
             InvestmentPrinciple principle = InvestmentPrinciple.create(
                 user,
                 principleGroup,
-                principleText,
+                item.getPrinciple(),
+                item.getDescription(),
                 i);
             principles.add(principle);
         }
@@ -126,7 +128,7 @@ public class InvestmentPrincipleService implements InvestmentPrincipleUseCase {
                     CodeEnum.FRS_003,
                     "투자원칙을 찾을 수 없습니다: " + command.getPrincipleId()));
 
-        principle.updatePrinciple(command.getPrinciple());
+        principle.updatePrinciple(command.getPrinciple(), command.getDescription());
         return principle;
     }
 

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlegroup/dto/CreatePrincipleGroupCommand.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlegroup/dto/CreatePrincipleGroupCommand.java
@@ -15,5 +15,12 @@ public class CreatePrincipleGroupCommand {
     private String groupName;
     private Integer displayOrder;
     private PrincipleType principleType;
-    private List<String> principles; // optional
+    private List<PrincipleItem> principles; // optional
+
+    @Getter
+    @AllArgsConstructor
+    public static class PrincipleItem {
+        private String principle;
+        private String description;
+    }
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlegroup/entity/PrincipleGroup.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlegroup/entity/PrincipleGroup.java
@@ -43,7 +43,6 @@ public class PrincipleGroup {
     @Column(name = "principle_type", nullable = false)
     private PrincipleType principleType;
 
-    @Column(nullable = false)
     private Integer displayOrder;
 
     @Column(updatable = false)

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlegroup/service/PrincipleGroupService.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlegroup/service/PrincipleGroupService.java
@@ -76,11 +76,15 @@ public class PrincipleGroupService implements PrincipleGroupUseCase {
         if (command.getPrinciples() != null && !command.getPrinciples().isEmpty()) {
             List<InvestmentPrinciple> principles = IntStream.range(0, command.getPrinciples().size())
                 .mapToObj(
-                    index -> InvestmentPrinciple.create(
-                        user,
-                        savedGroup,
-                        command.getPrinciples().get(index),
-                        index))
+                    index -> {
+                        CreatePrincipleGroupCommand.PrincipleItem item = command.getPrinciples().get(index);
+                        return InvestmentPrinciple.create(
+                            user,
+                            savedGroup,
+                            item.getPrinciple(),
+                            item.getDescription(),
+                            index);
+                    })
                 .collect(Collectors.toList());
 
             investmentPrincipleRepository.saveAll(principles);

--- a/stock-diary/src/main/resources/application.yml
+++ b/stock-diary/src/main/resources/application.yml
@@ -31,7 +31,7 @@ cloud:
 spring:
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
## 📌 관련 이슈
- Jira Ticket: [OGD-39](https://depromeet05.atlassian.net/browse/OGD-39)

## 🔍 PR의 이유

- 투자원칙 API에 `description`(설명) 필드가 누락되어 사용자가 투자원칙에 대한 상세한 설명을 추가할 수 없는 문제 발생
- RESTful API 설계 규칙에 따라 부분 수정 API의 HTTP 메서드가 `PUT`이 아닌 `PATCH`로 변경되어야 함

## ✨ 주요 변경사항

- [x] 투자원칙 엔티티에 `description` 컬럼 추가
- [x] 투자원칙 생성/수정/조회 API에 `description` 필드 추가
  - 단일 투자원칙 생성 API에 `description` 필드 추가
  - 다중 투자원칙 생성 API에 `description` 필드 추가 (Request DTO를 `PrincipleItem` 중첩 클래스로 구조 변경)
  - 투자원칙 수정 API에 `description` 필드 추가
  - 투자원칙 조회 Response에 `description` 필드 추가
- [x] 투자원칙 그룹 생성 API에 `description` 필드 추가
  - 그룹 생성 시 함께 생성되는 투자원칙에도 `description` 추가 가능하도록 Request DTO 구조 변경
- [x] 투자원칙 수정 API의 HTTP 메서드를 `PUT`에서 `PATCH`로 변경
- [x] 투자원칙 그룹 조회 시 정렬 순서 변경 (`displayOrder` → `id` 역순)
- [x] JPA DDL 설정을 `none`에서 `update`로 변경 (개발 환경 스키마 자동 업데이트용)
- [x] Command, Mapper, Service 레이어 전반에 걸쳐 `description` 필드 전파

## 📎 참고