### PR TITLE
[OGD-42] 투자원칙 그룹에 '썸네일' 필드 추가 및 api에 매수/매도 query param 추가

### DIFF
--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/principlegroup/controller/PrincipleGroupController.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/principlegroup/controller/PrincipleGroupController.java
@@ -6,14 +6,7 @@ import java.util.stream.Collectors;
 
 import jakarta.validation.Valid;
 
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import com.ogd.stockdiary.application.principlegroup.dto.mapper.PrincipleGroupMapper;
 import com.ogd.stockdiary.application.principlegroup.dto.request.CreatePrincipleGroupRequest;
@@ -22,6 +15,7 @@ import com.ogd.stockdiary.application.principlegroup.dto.request.UpdatePrinciple
 import com.ogd.stockdiary.application.principlegroup.dto.response.PrincipleGroupResponse;
 import com.ogd.stockdiary.common.httpresponse.HttpApiResponse;
 import com.ogd.stockdiary.domain.investmentprinciple.entity.InvestmentPrinciple;
+import com.ogd.stockdiary.domain.investmentprinciple.entity.PrincipleType;
 import com.ogd.stockdiary.domain.investmentprinciple.port.out.InvestmentPrincipleRepository;
 import com.ogd.stockdiary.domain.principlegroup.dto.CreatePrincipleGroupCommand;
 import com.ogd.stockdiary.domain.principlegroup.dto.ReorderPrincipleGroupsCommand;
@@ -45,12 +39,13 @@ public class PrincipleGroupController {
 
     @GetMapping
     @Operation(summary = "투자원칙 그룹 목록 조회", description = "사용자의 모든 투자원칙 그룹과 속한 원칙들을 조회합니다.")
-    public HttpApiResponse<List<PrincipleGroupResponse>> getUserPrincipleGroups() {
+    public HttpApiResponse<List<PrincipleGroupResponse>> getUserPrincipleGroups(
+        @RequestParam(required = false) PrincipleType type) {
 
         // TODO: Spring Security에서 User 정보 가져오기
         Long userId = 1L; // 임시로 하드코딩
 
-        List<PrincipleGroup> principleGroups = principleGroupUseCase.getUserPrincipleGroups(userId);
+        List<PrincipleGroup> principleGroups = principleGroupUseCase.getUserPrincipleGroups(userId, type);
 
         List<PrincipleGroupResponse> responses = principleGroups.stream()
             .sorted(Comparator.comparing(PrincipleGroup::getId).reversed())

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/principlegroup/dto/mapper/PrincipleGroupMapper.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/principlegroup/dto/mapper/PrincipleGroupMapper.java
@@ -30,12 +30,13 @@ public class PrincipleGroupMapper {
         }
         return new CreatePrincipleGroupCommand(
             userId, request.getGroupName(), request.getDisplayOrder(), request.getPrincipleType(),
-            commandItems);
+            request.getThumbnail(), commandItems);
     }
 
     public UpdatePrincipleGroupCommand toCommand(
         UpdatePrincipleGroupRequest request, Long groupId, Long userId) {
-        return new UpdatePrincipleGroupCommand(groupId, userId, request.getGroupName(), request.getPrincipleType());
+        return new UpdatePrincipleGroupCommand(groupId, userId, request.getGroupName(),
+            request.getPrincipleType(), request.getThumbnail());
     }
 
     public ReorderPrincipleGroupsCommand toReorderCommand(
@@ -59,6 +60,7 @@ public class PrincipleGroupMapper {
             principleGroup.getId(),
             principleGroup.getGroupName(),
             principleGroup.getPrincipleType(),
+            principleGroup.getThumbnail(),
             principleGroup.getDisplayOrder(),
             principleResponses);
     }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/principlegroup/dto/request/CreatePrincipleGroupRequest.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/principlegroup/dto/request/CreatePrincipleGroupRequest.java
@@ -31,6 +31,10 @@ public class CreatePrincipleGroupRequest {
     @NotNull(message = "투자원칙 타입은 필수입니다.")
     private PrincipleType principleType;
 
+    @Schema(description = "썸네일 (이모지 또는 이미지 URL)", example = "📈", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotBlank(message = "썸네일은 필수입니다")
+    private String thumbnail;
+
     @Schema(description = "그룹에 포함할 투자원칙 목록 (선택사항, 최대 5개)")
     @Size(max = 5, message = "그룹당 최대 5개의 투자원칙만 추가할 수 있습니다")
     @Valid

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/principlegroup/dto/request/UpdatePrincipleGroupRequest.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/principlegroup/dto/request/UpdatePrincipleGroupRequest.java
@@ -21,4 +21,8 @@ public class UpdatePrincipleGroupRequest {
 
     @Schema(description = "투자원칙 타입 (BUY: 매수, SELL: 매도) - 선택사항", example = "SELL")
     private PrincipleType principleType;
+
+    @Schema(description = "썸네일 (이모지 또는 이미지 URL)", example = "💪", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotBlank(message = "썸네일은 필수입니다")
+    private String thumbnail;
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/principlegroup/dto/response/PrincipleGroupResponse.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/principlegroup/dto/response/PrincipleGroupResponse.java
@@ -23,6 +23,9 @@ public class PrincipleGroupResponse {
     @Schema(description = "투자원칙 타입 (BUY: 매수, SELL: 매도)", example = "BUY")
     private final PrincipleType principleType;
 
+    @Schema(description = "썸네일 (이모지 또는 이미지 URL)", example = "📈")
+    private final String thumbnail;
+
     @Schema(description = "그룹 표시 순서", example = "1")
     private final Integer displayOrder;
 

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlegroup/dto/CreatePrincipleGroupCommand.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlegroup/dto/CreatePrincipleGroupCommand.java
@@ -15,6 +15,7 @@ public class CreatePrincipleGroupCommand {
     private String groupName;
     private Integer displayOrder;
     private PrincipleType principleType;
+    private String thumbnail;
     private List<PrincipleItem> principles; // optional
 
     @Getter

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlegroup/dto/UpdatePrincipleGroupCommand.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlegroup/dto/UpdatePrincipleGroupCommand.java
@@ -13,4 +13,5 @@ public class UpdatePrincipleGroupCommand {
     private Long userId;
     private String groupName;
     private PrincipleType principleType;
+    private String thumbnail;
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlegroup/entity/PrincipleGroup.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlegroup/entity/PrincipleGroup.java
@@ -43,6 +43,9 @@ public class PrincipleGroup {
     @Column(name = "principle_type", nullable = false)
     private PrincipleType principleType;
 
+    @Column(nullable = false)
+    private String thumbnail;
+
     private Integer displayOrder;
 
     @Column(updatable = false)
@@ -62,11 +65,12 @@ public class PrincipleGroup {
     }
 
     public static PrincipleGroup create(User user, String groupName, PrincipleType principleType,
-        Integer displayOrder) {
+        String thumbnail, Integer displayOrder) {
         PrincipleGroup principleGroup = new PrincipleGroup();
         principleGroup.user = user;
         principleGroup.groupName = groupName;
         principleGroup.principleType = principleType;
+        principleGroup.thumbnail = thumbnail;
         principleGroup.displayOrder = displayOrder;
         return principleGroup;
     }
@@ -77,6 +81,10 @@ public class PrincipleGroup {
 
     public void updatePrincipleType(PrincipleType principleType) {
         this.principleType = principleType;
+    }
+
+    public void updateThumbnail(String thumbnail) {
+        this.thumbnail = thumbnail;
     }
 
     public void updateDisplayOrder(Integer displayOrder) {

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlegroup/service/PrincipleGroupService.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlegroup/service/PrincipleGroupService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.ogd.stockdiary.application.user.repository.UserRepository;
 import com.ogd.stockdiary.common.httpresponse.CodeEnum;
 import com.ogd.stockdiary.domain.investmentprinciple.entity.InvestmentPrinciple;
+import com.ogd.stockdiary.domain.investmentprinciple.entity.PrincipleType;
 import com.ogd.stockdiary.domain.investmentprinciple.port.out.InvestmentPrincipleRepository;
 import com.ogd.stockdiary.domain.principlegroup.dto.CreatePrincipleGroupCommand;
 import com.ogd.stockdiary.domain.principlegroup.dto.ReorderPrincipleGroupsCommand;
@@ -33,8 +34,9 @@ public class PrincipleGroupService implements PrincipleGroupUseCase {
 
     @Override
     @Transactional(readOnly = true)
-    public List<PrincipleGroup> getUserPrincipleGroups(Long userId) {
-        return principleGroupRepository.findByUserId(userId);
+    public List<PrincipleGroup> getUserPrincipleGroups(Long userId, PrincipleType type) {
+        return principleGroupRepository.findByUserId(userId).stream()
+            .filter(pg -> type == null || pg.getPrincipleType().equals(type)).toList();
     }
 
     @Override

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlegroup/service/PrincipleGroupService.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlegroup/service/PrincipleGroupService.java
@@ -69,6 +69,7 @@ public class PrincipleGroupService implements PrincipleGroupUseCase {
             user,
             command.getGroupName(),
             command.getPrincipleType(),
+            command.getThumbnail(),
             command.getDisplayOrder());
         PrincipleGroup savedGroup = principleGroupRepository.save(principleGroup);
 
@@ -105,6 +106,9 @@ public class PrincipleGroupService implements PrincipleGroupUseCase {
         principleGroup.updateGroupName(command.getGroupName());
         if (command.getPrincipleType() != null) {
             principleGroup.updatePrincipleType(command.getPrincipleType());
+        }
+        if (command.getThumbnail() != null) {
+            principleGroup.updateThumbnail(command.getThumbnail());
         }
         return principleGroup;
     }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlegroup/usecase/PrincipleGroupUseCase.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlegroup/usecase/PrincipleGroupUseCase.java
@@ -2,6 +2,7 @@ package com.ogd.stockdiary.domain.principlegroup.usecase;
 
 import java.util.List;
 
+import com.ogd.stockdiary.domain.investmentprinciple.entity.PrincipleType;
 import com.ogd.stockdiary.domain.principlegroup.dto.CreatePrincipleGroupCommand;
 import com.ogd.stockdiary.domain.principlegroup.dto.ReorderPrincipleGroupsCommand;
 import com.ogd.stockdiary.domain.principlegroup.dto.UpdatePrincipleGroupCommand;
@@ -9,7 +10,7 @@ import com.ogd.stockdiary.domain.principlegroup.entity.PrincipleGroup;
 
 public interface PrincipleGroupUseCase {
 
-    List<PrincipleGroup> getUserPrincipleGroups(Long userId);
+    List<PrincipleGroup> getUserPrincipleGroups(Long userId, PrincipleType type);
 
     PrincipleGroup getPrincipleGroupById(Long groupId, Long userId);
 


### PR DESCRIPTION
## 📌 관련 이슈
- Jira Ticket: [OGD-42](https://depromeet05.atlassian.net/browse/OGD-42)

## 🔍 PR의 이유

- 투자원칙 그룹에 시각적 구분을 위한 썸네일(이모지/이미지) 필드가 필요
- 매수/매도 타입별로 그룹을 필터링해서 조회하는 기능 필요

## ✨ 주요 변경사항

- [x] `PrincipleGroup` 엔티티에 `thumbnail` 필드 추가
  - `@Column(nullable = false)` 필수 필드로 설정
  - `updateThumbnail()` 메서드 추가

- [x] 그룹 생성/수정 API에 썸네일 파라미터 추가
  - `CreatePrincipleGroupRequest`에 thumbnail 필드 추가 (필수, validation 포함)
  - `UpdatePrincipleGroupRequest`에 thumbnail 필드 추가 (필수, validation 포함)
  - 관련 Command DTO 및 Mapper 로직 업데이트

- [x] 그룹 조회 응답에 썸네일 정보 포함
  - `PrincipleGroupResponse`에 thumbnail 필드 추가

- [x] 타입별 그룹 필터링 기능 추가
  - `GET /api/v1/principle-groups?type={BUY|SELL}` 쿼리 파라미터 지원
  - `getUserPrincipleGroups()` 메서드에 `PrincipleType` 파라미터 추가
  - 서비스 레이어에서 타입별 필터링 로직 구현

## 📎 참고(선택)

- 썸네일은 이모지 또는 이미지 URL 형태로 사용 가능
- type 파라미터는 선택사항으로, 미지정 시 모든 타입의 그룹 반환