### PR TITLE
[OGD-40] 회고 메모 기능 개발

### DIFF
--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/controller/RetrospectionController.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/controller/RetrospectionController.java
@@ -2,22 +2,24 @@ package com.ogd.stockdiary.application.retrospection.controller;
 
 import jakarta.validation.Valid;
 
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.ogd.stockdiary.application.retrospection.dto.mapper.RetrospectionMapper;
+import com.ogd.stockdiary.application.retrospection.dto.request.CreateMemoRequest;
 import com.ogd.stockdiary.application.retrospection.dto.request.CreateRetrospectionRequest;
+import com.ogd.stockdiary.application.retrospection.dto.request.UpdateMemoRequest;
 import com.ogd.stockdiary.application.retrospection.dto.response.CreateRetrospectionResponse;
 import com.ogd.stockdiary.application.retrospection.dto.response.GetRetrospectionResponse;
 import com.ogd.stockdiary.common.httpresponse.HttpApiResponse;
 import com.ogd.stockdiary.domain.retrospection.entity.Retrospection;
-import com.ogd.stockdiary.domain.retrospection.port.in.CreateRetrospectionCommand;
-import com.ogd.stockdiary.domain.retrospection.port.in.CreateRetrospectionUseCase;
-import com.ogd.stockdiary.domain.retrospection.port.in.GetRetrospectionUseCase;
+import com.ogd.stockdiary.domain.retrospection.port.in.*;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -31,6 +33,9 @@ public class RetrospectionController {
 
     private final CreateRetrospectionUseCase createRetrospectionUseCase;
     private final GetRetrospectionUseCase getRetrospectionUseCase;
+    private final CreateMemoUseCase createMemoUseCase;
+    private final UpdateMemoUseCase updateMemoUseCase;
+    private final DeleteMemoUseCase deleteMemoUseCase;
 
     @PostMapping
     @Operation(summary = "회고 생성", description = "주식 거래 회고를 생성합니다.")
@@ -58,5 +63,50 @@ public class RetrospectionController {
         GetRetrospectionResponse response = getRetrospectionUseCase.getRetrospection(retrospectionId, userId);
 
         return HttpApiResponse.of(response);
+    }
+
+    // Memo CRUD endpoints
+
+    @PostMapping("/{retrospectionId}/memos")
+    @Operation(summary = "메모 생성", description = "회고에 메모를 추가합니다.")
+    public HttpApiResponse<String> createMemo(
+        @PathVariable Long retrospectionId,
+        @Valid @RequestBody CreateMemoRequest request) {
+
+        // TODO: Spring Security에서 User 정보 가져오기
+        Long userId = 1L; // 임시로 하드코딩
+
+        createMemoUseCase.createMemo(retrospectionId, request.getContent(), userId);
+
+        return HttpApiResponse.of("success");
+    }
+
+    @PutMapping("/{retrospectionId}/memos/{memoId}")
+    @Operation(summary = "메모 수정", description = "메모 내용을 수정합니다.")
+    public HttpApiResponse<String> updateMemo(
+        @PathVariable Long retrospectionId,
+        @PathVariable Long memoId,
+        @Valid @RequestBody UpdateMemoRequest request) {
+
+        // TODO: Spring Security에서 User 정보 가져오기
+        Long userId = 1L; // 임시로 하드코딩
+
+        updateMemoUseCase.updateMemo(retrospectionId, memoId, request.getContent(), userId);
+
+        return HttpApiResponse.of("success");
+    }
+
+    @DeleteMapping("/{retrospectionId}/memos/{memoId}")
+    @Operation(summary = "메모 삭제", description = "메모를 삭제합니다.")
+    public HttpApiResponse<String> deleteMemo(
+        @PathVariable Long retrospectionId,
+        @PathVariable Long memoId) {
+
+        // TODO: Spring Security에서 User 정보 가져오기
+        Long userId = 1L; // 임시로 하드코딩
+
+        deleteMemoUseCase.deleteMemo(retrospectionId, memoId, userId);
+
+        return HttpApiResponse.of("success");
     }
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/dto/mapper/MemoMapper.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/dto/mapper/MemoMapper.java
@@ -1,0 +1,23 @@
+package com.ogd.stockdiary.application.retrospection.dto.mapper;
+
+import com.ogd.stockdiary.application.retrospection.dto.response.CreateMemoResponse;
+import com.ogd.stockdiary.application.retrospection.dto.response.MemoResponse;
+import com.ogd.stockdiary.domain.retrospection.entity.Memo;
+
+public class MemoMapper {
+
+    public static CreateMemoResponse toCreateResponse(Memo memo) {
+        return new CreateMemoResponse(
+            memo.getId(),
+            memo.getContent(),
+            memo.getUserId(),
+            memo.getCreatedAt(),
+            memo.getUpdatedAt());
+    }
+
+    public static MemoResponse toResponse(Memo memo) {
+        return new MemoResponse(
+            memo.getId(),
+            memo.getContent());
+    }
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/dto/mapper/RetrospectionMapper.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/dto/mapper/RetrospectionMapper.java
@@ -8,8 +8,10 @@ import com.ogd.stockdiary.application.principlecheck.dto.request.PrincipleCheckR
 import com.ogd.stockdiary.application.retrospection.dto.request.CreateRetrospectionRequest;
 import com.ogd.stockdiary.application.retrospection.dto.response.CreateRetrospectionResponse;
 import com.ogd.stockdiary.application.retrospection.dto.response.GetRetrospectionResponse;
+import com.ogd.stockdiary.application.retrospection.dto.response.MemoResponse;
 import com.ogd.stockdiary.domain.principlecheck.dto.PrincipleCheckCommand;
 import com.ogd.stockdiary.domain.principlecheck.entity.PrincipleCheck;
+import com.ogd.stockdiary.domain.retrospection.entity.Memo;
 import com.ogd.stockdiary.domain.retrospection.entity.Order;
 import com.ogd.stockdiary.domain.retrospection.entity.Retrospection;
 import com.ogd.stockdiary.domain.retrospection.port.in.CreateRetrospectionCommand;
@@ -89,7 +91,8 @@ public class RetrospectionMapper {
         Retrospection retrospection,
         List<PrincipleCheck> principleChecks,
         Map<Long, List<String>> imageUrlsMap,
-        Map<Long, List<String>> linksMap) {
+        Map<Long, List<String>> linksMap,
+        List<Memo> memos) {
         List<GetRetrospectionResponse.PrincipleCheckResponse> principleCheckResponses = principleChecks.stream()
             .map(pc -> new GetRetrospectionResponse.PrincipleCheckResponse(
                 pc.getPrinciple().getId(),
@@ -98,6 +101,10 @@ public class RetrospectionMapper {
                 pc.getReason(),
                 imageUrlsMap.getOrDefault(pc.getId(), Collections.emptyList()),
                 linksMap.getOrDefault(pc.getId(), Collections.emptyList())))
+            .toList();
+
+        List<MemoResponse> memoResponses = memos.stream()
+            .map(MemoMapper::toResponse)
             .toList();
 
         return new GetRetrospectionResponse(
@@ -114,6 +121,7 @@ public class RetrospectionMapper {
             retrospection.getContent(),
             retrospection.getEmotion(),
             principleCheckResponses,
+            memoResponses,
             retrospection.getCreatedAt(),
             retrospection.getUpdatedAt());
     }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/dto/request/CreateMemoRequest.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/dto/request/CreateMemoRequest.java
@@ -1,0 +1,17 @@
+package com.ogd.stockdiary.application.retrospection.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+@Schema(description = "메모 생성 요청 정보")
+public class CreateMemoRequest {
+
+    @Schema(description = "메모 내용", example = "이번 거래에서 감정적으로 판단한 부분이 있었다.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotBlank(message = "메모 내용은 필수입니다")
+    private String content;
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/dto/request/UpdateMemoRequest.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/dto/request/UpdateMemoRequest.java
@@ -1,0 +1,17 @@
+package com.ogd.stockdiary.application.retrospection.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+@Schema(description = "메모 수정 요청 정보")
+public class UpdateMemoRequest {
+
+    @Schema(description = "메모 내용", example = "수정된 메모 내용입니다.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotBlank(message = "메모 내용은 필수입니다")
+    private String content;
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/dto/response/CreateMemoResponse.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/dto/response/CreateMemoResponse.java
@@ -1,0 +1,28 @@
+package com.ogd.stockdiary.application.retrospection.dto.response;
+
+import java.time.LocalDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+@Schema(description = "메모 생성 응답 정보")
+public class CreateMemoResponse {
+
+    @Schema(description = "메모 ID", example = "1")
+    private Long memoId;
+
+    @Schema(description = "메모 내용", example = "이번 거래에서 감정적으로 판단한 부분이 있었다.")
+    private String content;
+
+    @Schema(description = "작성자 ID", example = "1")
+    private Long userId;
+
+    @Schema(description = "생성일시", example = "2025-09-14T10:00:00")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "수정일시", example = "2025-09-14T10:00:00")
+    private LocalDateTime updatedAt;
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/dto/response/GetRetrospectionResponse.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/dto/response/GetRetrospectionResponse.java
@@ -58,6 +58,9 @@ public class GetRetrospectionResponse {
     @Schema(description = "투자 원칙 목록")
     private List<PrincipleCheckResponse> principleChecks;
 
+    @Schema(description = "메모 목록")
+    private List<MemoResponse> memos;
+
     @Schema(description = "생성일시", example = "2025-09-14T10:00:00")
     private LocalDateTime createdAt;
 

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/dto/response/MemoResponse.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/dto/response/MemoResponse.java
@@ -1,0 +1,17 @@
+package com.ogd.stockdiary.application.retrospection.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+@Schema(description = "메모 응답 정보")
+public class MemoResponse {
+
+    @Schema(description = "메모 ID", example = "1")
+    private Long memoId;
+
+    @Schema(description = "메모 내용", example = "이번 거래에서 감정적으로 판단한 부분이 있었다.")
+    private String content;
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/repository/JpaMemoRepository.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/repository/JpaMemoRepository.java
@@ -1,0 +1,12 @@
+package com.ogd.stockdiary.application.retrospection.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.ogd.stockdiary.domain.retrospection.entity.Memo;
+
+public interface JpaMemoRepository extends JpaRepository<Memo, Long> {
+
+    List<Memo> findByRetrospectionIdOrderByIdDesc(Long retrospectionId);
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/repository/MemoRepositoryImpl.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/repository/MemoRepositoryImpl.java
@@ -1,0 +1,42 @@
+package com.ogd.stockdiary.application.retrospection.repository;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.ogd.stockdiary.common.httpresponse.CodeEnum;
+import com.ogd.stockdiary.domain.retrospection.entity.Memo;
+import com.ogd.stockdiary.domain.retrospection.port.out.MemoRepository;
+import com.ogd.stockdiary.exception.ApplicationException;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class MemoRepositoryImpl implements MemoRepository {
+
+    private final JpaMemoRepository jpaMemoRepository;
+
+    @Override
+    public Memo save(Memo memo) {
+        return jpaMemoRepository.save(memo);
+    }
+
+    @Override
+    public Memo getById(Long id) {
+        return jpaMemoRepository
+            .findById(id)
+            .orElseThrow(
+                () -> new ApplicationException(CodeEnum.FRS_003, "메모를 찾을 수 없습니다: " + id));
+    }
+
+    @Override
+    public List<Memo> findByRetrospectionIdOrderByIdDesc(Long retrospectionId) {
+        return jpaMemoRepository.findByRetrospectionIdOrderByIdDesc(retrospectionId);
+    }
+
+    @Override
+    public void delete(Memo memo) {
+        jpaMemoRepository.delete(memo);
+    }
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/service/RetrospectionService.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/service/RetrospectionService.java
@@ -25,10 +25,15 @@ import com.ogd.stockdiary.domain.principlecheck.dto.PrincipleCheckCommand;
 import com.ogd.stockdiary.domain.principlecheck.entity.PrincipleCheck;
 import com.ogd.stockdiary.domain.principlecheck.entity.PrincipleCheckLink;
 import com.ogd.stockdiary.domain.principlecheck.port.out.PrincipleCheckRepository;
+import com.ogd.stockdiary.domain.retrospection.entity.Memo;
 import com.ogd.stockdiary.domain.retrospection.entity.Retrospection;
+import com.ogd.stockdiary.domain.retrospection.port.in.CreateMemoUseCase;
 import com.ogd.stockdiary.domain.retrospection.port.in.CreateRetrospectionCommand;
 import com.ogd.stockdiary.domain.retrospection.port.in.CreateRetrospectionUseCase;
+import com.ogd.stockdiary.domain.retrospection.port.in.DeleteMemoUseCase;
 import com.ogd.stockdiary.domain.retrospection.port.in.GetRetrospectionUseCase;
+import com.ogd.stockdiary.domain.retrospection.port.in.UpdateMemoUseCase;
+import com.ogd.stockdiary.domain.retrospection.port.out.MemoRepository;
 import com.ogd.stockdiary.domain.retrospection.port.out.RetrospectionRepository;
 import com.ogd.stockdiary.domain.user.entity.User;
 import com.ogd.stockdiary.exception.ApplicationException;
@@ -37,7 +42,13 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
-public class RetrospectionService implements CreateRetrospectionUseCase, GetRetrospectionUseCase {
+public class RetrospectionService
+    implements
+        CreateRetrospectionUseCase,
+        GetRetrospectionUseCase,
+        CreateMemoUseCase,
+        UpdateMemoUseCase,
+        DeleteMemoUseCase {
 
     private final RetrospectionRepository retrospectionRepository;
     private final UserRepository userRepository;
@@ -47,6 +58,7 @@ public class RetrospectionService implements CreateRetrospectionUseCase, GetRetr
     private final JpaPrincipleCheckImageRepository principleCheckImageRepository;
     private final JpaPrincipleCheckLinkRepository principleCheckLinkRepository;
     private final ImageUseCase imageUseCase;
+    private final MemoRepository memoRepository;
 
     @Override
     @Transactional
@@ -152,7 +164,10 @@ public class RetrospectionService implements CreateRetrospectionUseCase, GetRetr
                 PrincipleCheck::getId,
                 pc -> getLinks(pc.getId())));
 
-        return RetrospectionMapper.toGetResponse(retrospection, principleChecks, imageUrlsMap, linksMap);
+        // 메모 목록 조회 (최신순 정렬)
+        List<Memo> memos = memoRepository.findByRetrospectionIdOrderByIdDesc(retrospectionId);
+
+        return RetrospectionMapper.toGetResponse(retrospection, principleChecks, imageUrlsMap, linksMap, memos);
     }
 
     private List<String> getImageUrls(Long principleCheckId) {
@@ -171,5 +186,72 @@ public class RetrospectionService implements CreateRetrospectionUseCase, GetRetr
         return principleCheckLinks.stream()
             .map(PrincipleCheckLink::getLinkUrl)
             .toList();
+    }
+
+    // Memo CRUD operations
+
+    @Override
+    @Transactional
+    public Memo createMemo(Long retrospectionId, String content, Long userId) {
+        // 회고 존재 및 권한 확인
+        Retrospection retrospection = retrospectionRepository.findByIdAndUserId(retrospectionId, userId);
+
+        // 메모 생성 및 저장
+        Memo memo = Memo.create(retrospection, content, userId);
+        return memoRepository.save(memo);
+    }
+
+    @Override
+    @Transactional
+    public void updateMemo(Long retrospectionId, Long memoId, String content, Long userId) {
+        // 회고 권한 확인
+        retrospectionRepository.findByIdAndUserId(retrospectionId, userId);
+
+        // 메모 조회
+        Memo memo = memoRepository.getById(memoId);
+
+        // 메모 작성자 확인
+        if (!memo.getUserId().equals(userId)) {
+            throw new ApplicationException(
+                CodeEnum.FRS_003,
+                "해당 메모에 대한 권한이 없습니다: " + memoId);
+        }
+
+        // 메모가 해당 회고에 속하는지 확인
+        if (!memo.getRetrospection().getId().equals(retrospectionId)) {
+            throw new ApplicationException(
+                CodeEnum.FRS_003,
+                "해당 메모는 이 회고에 속하지 않습니다: " + memoId);
+        }
+
+        // 메모 수정
+        memo.updateContent(content);
+    }
+
+    @Override
+    @Transactional
+    public void deleteMemo(Long retrospectionId, Long memoId, Long userId) {
+        // 회고 권한 확인
+        retrospectionRepository.findByIdAndUserId(retrospectionId, userId);
+
+        // 메모 조회
+        Memo memo = memoRepository.getById(memoId);
+
+        // 메모 작성자 확인
+        if (!memo.getUserId().equals(userId)) {
+            throw new ApplicationException(
+                CodeEnum.FRS_003,
+                "해당 메모에 대한 권한이 없습니다: " + memoId);
+        }
+
+        // 메모가 해당 회고에 속하는지 확인
+        if (!memo.getRetrospection().getId().equals(retrospectionId)) {
+            throw new ApplicationException(
+                CodeEnum.FRS_003,
+                "해당 메모는 이 회고에 속하지 않습니다: " + memoId);
+        }
+
+        // 메모 삭제
+        memoRepository.delete(memo);
     }
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/retrospection/entity/Memo.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/retrospection/entity/Memo.java
@@ -1,0 +1,67 @@
+package com.ogd.stockdiary.domain.retrospection.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "memos")
+@Getter
+@NoArgsConstructor
+public class Memo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "retrospection_id", nullable = false)
+    private Retrospection retrospection;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public static Memo create(Retrospection retrospection, String content, Long userId) {
+        Memo memo = new Memo();
+        memo.retrospection = retrospection;
+        memo.content = content;
+        memo.userId = userId;
+        return memo;
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/retrospection/port/in/CreateMemoUseCase.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/retrospection/port/in/CreateMemoUseCase.java
@@ -1,0 +1,8 @@
+package com.ogd.stockdiary.domain.retrospection.port.in;
+
+import com.ogd.stockdiary.domain.retrospection.entity.Memo;
+
+public interface CreateMemoUseCase {
+
+    Memo createMemo(Long retrospectionId, String content, Long userId);
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/retrospection/port/in/DeleteMemoUseCase.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/retrospection/port/in/DeleteMemoUseCase.java
@@ -1,0 +1,6 @@
+package com.ogd.stockdiary.domain.retrospection.port.in;
+
+public interface DeleteMemoUseCase {
+
+    void deleteMemo(Long retrospectionId, Long memoId, Long userId);
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/retrospection/port/in/UpdateMemoUseCase.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/retrospection/port/in/UpdateMemoUseCase.java
@@ -1,0 +1,6 @@
+package com.ogd.stockdiary.domain.retrospection.port.in;
+
+public interface UpdateMemoUseCase {
+
+    void updateMemo(Long retrospectionId, Long memoId, String content, Long userId);
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/retrospection/port/out/MemoRepository.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/retrospection/port/out/MemoRepository.java
@@ -1,0 +1,16 @@
+package com.ogd.stockdiary.domain.retrospection.port.out;
+
+import java.util.List;
+
+import com.ogd.stockdiary.domain.retrospection.entity.Memo;
+
+public interface MemoRepository {
+
+    Memo save(Memo memo);
+
+    Memo getById(Long id);
+
+    List<Memo> findByRetrospectionIdOrderByIdDesc(Long retrospectionId);
+
+    void delete(Memo memo);
+}


### PR DESCRIPTION
## 📌 관련 이슈
- Jira Ticket: [OGD-40](https://depromeet05.atlassian.net/browse/OGD-40)

## 🔍 PR의 이유

- 주식 거래 회고에 메모 기능이 필요하여 CRUD API 추가
- 사용자가 회고 내용에 추가로 간단한 메모를 작성하고 관리할 수 있도록 개선

## ✨ 주요 변경사항

- [x] `Memo` 엔티티 추가 (도메인 모델 정의)
  - `Retrospection`과 N:1 관계 설정
  - 메모 내용, 작성자, 생성/수정 일시 관리

- [x] 메모 관련 Use Case 인터페이스 추가
  - `CreateMemoUseCase`: 메모 생성
  - `UpdateMemoUseCase`: 메모 수정
  - `DeleteMemoUseCase`: 메모 삭제

- [x] 메모 Repository 계층 구현
  - `MemoRepository` 인터페이스 (포트)
  - `JpaMemoRepository` 인터페이스 (JPA)
  - `MemoRepositoryImpl` 구현체

- [x] `RetrospectionController`에 메모 CRUD 엔드포인트 추가
  - `POST /api/v1/retrospections/{retrospectionId}/memos`: 메모 생성
  - `PUT /api/v1/retrospections/{retrospectionId}/memos/{memoId}`: 메모 수정
  - `DELETE /api/v1/retrospections/{retrospectionId}/memos/{memoId}`: 메모 삭제

- [x] `RetrospectionService`에 메모 비즈니스 로직 구현
  - 메모 생성/수정/삭제 시 권한 검증 (작성자 확인)
  - 메모가 해당 회고에 속하는지 검증

- [x] 메모 관련 DTO 추가
  - `CreateMemoRequest`: 메모 생성 요청
  - `UpdateMemoRequest`: 메모 수정 요청
  - `CreateMemoResponse`: 메모 생성 응답
  - `MemoResponse`: 메모 조회 응답
  - `MemoMapper`: DTO 매핑 유틸리티

- [x] 회고 조회 시 메모 목록 포함
  - `GetRetrospectionResponse`에 메모 목록 필드 추가
  - 메모는 최신순으로 정렬하여 반환

## 📎 참고