### PR TITLE
[OGD-38] 추천 투자 원칙 그룹 목록 조회 API 개발

### DIFF
--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/principlegroup/controller/PrincipleGroupController.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/principlegroup/controller/PrincipleGroupController.java
@@ -60,6 +60,27 @@ public class PrincipleGroupController {
         return HttpApiResponse.of(responses);
     }
 
+    @GetMapping("/recommendations")
+    @Operation(summary = "추천 투자원칙 그룹 목록 조회", description = "시스템의 추천 투자원칙 그룹 목록을 조회합니다.")
+    public HttpApiResponse<List<PrincipleGroupResponse>> getRecommendationPrincipleGroups() {
+        // userId가 0인 투자원칙 그룹들은 시스템 디폴트 투자원칙 그룹이다.
+        Long userId = 0L;
+
+        List<PrincipleGroup> principleGroups = principleGroupUseCase.getUserPrincipleGroups(userId, null);
+
+        List<PrincipleGroupResponse> responses = principleGroups.stream()
+            .sorted(Comparator.comparing(PrincipleGroup::getId).reversed())
+            .map(
+                group -> {
+                    List<InvestmentPrinciple> principles = investmentPrincipleRepository.findByPrincipleGroupId(
+                        group.getId());
+                    return principleGroupMapper.toResponse(group, principles);
+                })
+            .collect(Collectors.toList());
+
+        return HttpApiResponse.of(responses);
+    }
+
     @GetMapping("/{groupId}")
     @Operation(summary = "투자원칙 그룹 조회", description = "특정 투자원칙 그룹과 속한 원칙들을 조회합니다.")
     public HttpApiResponse<PrincipleGroupResponse> getPrincipleGroupById(

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/controller/RetrospectionController.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/controller/RetrospectionController.java
@@ -33,6 +33,7 @@ public class RetrospectionController {
 
     private final CreateRetrospectionUseCase createRetrospectionUseCase;
     private final GetRetrospectionUseCase getRetrospectionUseCase;
+    private final DeleteRetrospectionUseCase deleteRetrospectionUseCase;
     private final CreateMemoUseCase createMemoUseCase;
     private final UpdateMemoUseCase updateMemoUseCase;
     private final DeleteMemoUseCase deleteMemoUseCase;
@@ -63,6 +64,17 @@ public class RetrospectionController {
         GetRetrospectionResponse response = getRetrospectionUseCase.getRetrospection(retrospectionId, userId);
 
         return HttpApiResponse.of(response);
+    }
+
+    @DeleteMapping("/{retrospectionId}")
+    @Operation(summary = "회고 삭제", description = "회고 id로 회고를 삭제합니다.")
+    public HttpApiResponse<String> delete(@PathVariable Long retrospectionId) {
+        // TODO: Spring Security에서 User 정보 가져오기
+        Long userId = 1L;
+
+        deleteRetrospectionUseCase.deleteRetrospection(retrospectionId);
+
+        return HttpApiResponse.of("success");
     }
 
     // Memo CRUD endpoints

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/repository/RetrospectionRepositoryImpl.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/repository/RetrospectionRepositoryImpl.java
@@ -37,4 +37,9 @@ public class RetrospectionRepositoryImpl implements RetrospectionRepository {
                     CodeEnum.FRS_003,
                     "유저(" + userId + ")에 해당하는 회고(" + id + ")를 찾을 수 없습니다: "));
     }
+
+    @Override
+    public void deleteById(Long id) {
+        jpaRetrospectionRepository.deleteById(id);
+    }
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/service/RetrospectionService.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/service/RetrospectionService.java
@@ -27,12 +27,7 @@ import com.ogd.stockdiary.domain.principlecheck.entity.PrincipleCheckLink;
 import com.ogd.stockdiary.domain.principlecheck.port.out.PrincipleCheckRepository;
 import com.ogd.stockdiary.domain.retrospection.entity.Memo;
 import com.ogd.stockdiary.domain.retrospection.entity.Retrospection;
-import com.ogd.stockdiary.domain.retrospection.port.in.CreateMemoUseCase;
-import com.ogd.stockdiary.domain.retrospection.port.in.CreateRetrospectionCommand;
-import com.ogd.stockdiary.domain.retrospection.port.in.CreateRetrospectionUseCase;
-import com.ogd.stockdiary.domain.retrospection.port.in.DeleteMemoUseCase;
-import com.ogd.stockdiary.domain.retrospection.port.in.GetRetrospectionUseCase;
-import com.ogd.stockdiary.domain.retrospection.port.in.UpdateMemoUseCase;
+import com.ogd.stockdiary.domain.retrospection.port.in.*;
 import com.ogd.stockdiary.domain.retrospection.port.out.MemoRepository;
 import com.ogd.stockdiary.domain.retrospection.port.out.RetrospectionRepository;
 import com.ogd.stockdiary.domain.user.entity.User;
@@ -46,6 +41,7 @@ public class RetrospectionService
     implements
         CreateRetrospectionUseCase,
         GetRetrospectionUseCase,
+        DeleteRetrospectionUseCase,
         CreateMemoUseCase,
         UpdateMemoUseCase,
         DeleteMemoUseCase {
@@ -253,5 +249,11 @@ public class RetrospectionService
 
         // 메모 삭제
         memoRepository.delete(memo);
+    }
+
+    @Override
+    @Transactional
+    public void deleteRetrospection(Long retrospectionId) {
+        retrospectionRepository.deleteById(retrospectionId);
     }
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/investmentprinciple/entity/InvestmentPrinciple.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/investmentprinciple/entity/InvestmentPrinciple.java
@@ -3,8 +3,10 @@ package com.ogd.stockdiary.domain.investmentprinciple.entity;
 import java.time.LocalDateTime;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -33,11 +35,11 @@ public class InvestmentPrinciple {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "user_id", nullable = false, foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "group_id", nullable = false)
+    @JoinColumn(name = "group_id", nullable = false, foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
     private PrincipleGroup principleGroup;
 
     private String principle;

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlecheck/entity/PrincipleCheck.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlecheck/entity/PrincipleCheck.java
@@ -3,10 +3,12 @@ package com.ogd.stockdiary.domain.principlecheck.entity;
 import java.time.LocalDateTime;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -33,11 +35,11 @@ public class PrincipleCheck {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "retrospection_id", nullable = false)
+    @JoinColumn(name = "retrospection_id", nullable = false, foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
     private Retrospection retrospection;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "principle_id", nullable = false)
+    @JoinColumn(name = "principle_id", nullable = false, foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
     private InvestmentPrinciple principle;
 
     @Enumerated(EnumType.STRING)

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlegroup/entity/PrincipleGroup.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlegroup/entity/PrincipleGroup.java
@@ -2,19 +2,7 @@ package com.ogd.stockdiary.domain.principlegroup.entity;
 
 import java.time.LocalDateTime;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.PrePersist;
-import jakarta.persistence.PreUpdate;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 
 import com.ogd.stockdiary.domain.investmentprinciple.entity.PrincipleType;
 import com.ogd.stockdiary.domain.user.entity.User;
@@ -33,7 +21,7 @@ public class PrincipleGroup {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "user_id", nullable = false, foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
     private User user;
 
     @Column(nullable = false)

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/retrospection/entity/Memo.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/retrospection/entity/Memo.java
@@ -3,8 +3,10 @@ package com.ogd.stockdiary.domain.retrospection.entity;
 import java.time.LocalDateTime;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -28,7 +30,7 @@ public class Memo {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "retrospection_id", nullable = false)
+    @JoinColumn(name = "retrospection_id", nullable = false, foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
     private Retrospection retrospection;
 
     @Column(nullable = false, columnDefinition = "TEXT")

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/retrospection/entity/Retrospection.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/retrospection/entity/Retrospection.java
@@ -3,11 +3,13 @@ package com.ogd.stockdiary.domain.retrospection.entity;
 import java.time.LocalDateTime;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -33,7 +35,7 @@ public class Retrospection {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "user_id", nullable = false, foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
     private User user;
 
     @Column(nullable = false, length = 20)

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/retrospection/port/in/DeleteRetrospectionUseCase.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/retrospection/port/in/DeleteRetrospectionUseCase.java
@@ -1,0 +1,6 @@
+package com.ogd.stockdiary.domain.retrospection.port.in;
+
+public interface DeleteRetrospectionUseCase {
+
+    void deleteRetrospection(Long retrospectionId);
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/retrospection/port/out/RetrospectionRepository.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/retrospection/port/out/RetrospectionRepository.java
@@ -9,4 +9,6 @@ public interface RetrospectionRepository {
     Retrospection getById(Long id);
 
     Retrospection findByIdAndUserId(Long id, Long userId);
+
+    void deleteById(Long id);
 }


### PR DESCRIPTION
## 📌 관련 이슈
- Jira Ticket: [OGD-38](https://depromeet05.atlassian.net/browse/OGD-38)

## 🔍 PR의 이유

- OGD-38: 추천 투자원칙 그룹 목록 조회 API 개발 및 회고 삭제 기능 추가
- 시스템에서 제공하는 추천 투자원칙 그룹 목록을 사용자가 조회할 수 있도록 API 엔드포인트 추가
- 사용자가 작성한 회고를 삭제할 수 있는 기능 누락으로 인한 기능 추가
- 외래키 제약조건 설정으로 인한 데이터 삭제 오류 방지를 위한 FK 제약조건 제거

## ✨ 주요 변경사항

- [x] **추천 투자원칙 그룹 조회 API 추가**
  - `GET /principle-groups/recommendations` 엔드포인트 신규 추가
  - userId가 0인 시스템 디폴트 투자원칙 그룹 목록 조회
  - 최신순으로 정렬하여 반환

- [x] **회고 삭제 기능 구현**
  - `DELETE /retrospections/{retrospectionId}` 엔드포인트 신규 추가
  - `DeleteRetrospectionUseCase` 인터페이스 신규 추가
  - `RetrospectionRepository`에 `deleteById` 메서드 추가
  - `RetrospectionService`에 회고 삭제 로직 구현

- [x] **JPA 외래키 제약조건 제거**
  - 모든 도메인 엔티티의 `@JoinColumn`에 `foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT)` 추가
  - 대상 엔티티: `InvestmentPrinciple`, `PrincipleCheck`, `PrincipleGroup`, `Memo`, `Retrospection`
  - 데이터 삭제 시 외래키 제약조건으로 인한 오류 방지

- [x] **코드 정리**
  - `RetrospectionService`의 import 문 와일드카드로 정리
  - `PrincipleGroup` 엔티티의 import 문 와일드카드로 정리

## 📎 참고

- 추천 투자원칙 그룹은 userId가 0인 시스템 디폴트 데이터로 관리됩니다.
- FK 제약조건 제거는 애플리케이션 레벨에서 데이터 정합성을 관리하기 위한 조치입니다.
- 회고 삭제 시 Spring Security 인증 정보 연동은 추후 구현 예정입니다. (현재 userId=1L로 하드코딩)