### PR TITLE
[OGD-44] ios 카카오로그인시 idToken으로 소셜로그인에 사용

### DIFF
--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/user/controller/AuthController.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/user/controller/AuthController.java
@@ -33,47 +33,63 @@ public class AuthController {
     @Operation(summary = "소셜 로그인 (Kakao, Apple)", description = """
         ## 소셜 로그인 API
 
-        OAuth 2.0 Authorization Code Flow를 사용한 소셜 로그인 API입니다.
+        OAuth 2.0을 사용한 소셜 로그인 API입니다. 웹, Android, iOS 모두 지원합니다.
 
         ### 사용 방법
 
-        #### 1. Kakao 로그인
+        #### 1. Kakao - iOS SDK
+        ```json
+        {
+          "provider": "KAKAO",
+          "authCode": null,
+          "idToken": "SDK로부터 받은 idToken",  // oauthToken.idToken
+          "redirectUri": null,
+          "email": null,     // idToken에서 자동 추출
+          "nickname": null   // idToken에서 자동 추출
+        }
+        ```
+
+        #### 2. Kakao - 웹/Android
         ```json
         {
           "provider": "KAKAO",
           "authCode": "SDK로부터 받은 authCode",
+          "idToken": null,
           "redirectUri": "kakao{YOUR_APP_KEY}://oauth",  // SDK가 사용한 redirect_uri
-          "email": null,     // null 가능 (idToken에서 자동 추출)
-          "nickname": null   // null 가능 (idToken에서 자동 추출)
+          "email": null,     // idToken에서 자동 추출
+          "nickname": null   // idToken에서 자동 추출
         }
         ```
 
-        #### 2. Apple 첫 로그인
+        #### 3. Apple - iOS SDK 첫 로그인
         ```json
         {
           "provider": "APPLE",
-          "authCode": "SDK로부터 받은 authCode",
-          "redirectUri": "your.app.bundle.id",
+          "authCode": null,
+          "idToken": "SDK로부터 받은 idToken",  // credential.identityToken
+          "redirectUri": null,
           "email": "user@example.com",    // Apple SDK가 제공한 값 (필수)
           "nickname": "홍길동"             // Apple SDK가 제공한 값 (필수)
         }
         ```
 
-        #### 3. Apple 재로그인
+        #### 4. Apple - iOS SDK 재로그인
         ```json
         {
           "provider": "APPLE",
-          "authCode": "SDK로부터 받은 authCode",
-          "redirectUri": "your.app.bundle.id",
+          "authCode": null,
+          "idToken": "SDK로부터 받은 idToken",
+          "redirectUri": null,
           "email": null,     // null 가능 (DB에 저장된 값 사용)
           "nickname": null   // null 가능 (DB에 저장된 값 사용)
         }
         ```
 
         ### 주의사항
-        - **redirectUri**: authCode 획득 시 사용한 redirect_uri와 동일해야 함 (OAuth 2.0 보안 요구사항)
-        - **Apple**: 첫 로그인 시에만 email/nickname 제공, 재로그인 시에는 null
-        - **Kakao**: email/nickname은 idToken payload에서 자동 추출되므로 null 전달 가능
+        - **iOS SDK**: idToken 사용 (authCode는 null)
+        - **웹/Android**: authCode 사용 (idToken은 null)
+        - **redirectUri**: authCode 사용 시에만 필요 (OAuth 2.0 보안 요구사항)
+        - **Apple 첫 로그인**: email/nickname 필수, 재로그인 시에는 null 가능
         """)
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "로그인 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = SocialLoginResponse.class), examples = @ExampleObject(value = """
@@ -107,6 +123,7 @@ public class AuthController {
         AuthResult authResult = authService.socialLogin(
             request.getProvider(),
             request.getAuthCode(),
+            request.getIdToken(),
             request.getRedirectUri(),
             request.getEmail(),
             request.getNickname());
@@ -122,6 +139,7 @@ public class AuthController {
         AuthResult authResult = authService.socialLogin(
             com.ogd.stockdiary.domain.user.entity.OAuthProvider.APPLE,
             code,
+            null, // idToken
             null, // redirectUri는 application.yml의 설정 사용
             null,
             null);
@@ -137,6 +155,7 @@ public class AuthController {
         AuthResult authResult = authService.socialLogin(
             OAuthProvider.KAKAO,
             code,
+            null, // idToken
             null, // redirectUri는 application.yml의 설정 사용
             null,
             null);

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/user/dto/SocialLoginRequest.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/user/dto/SocialLoginRequest.java
@@ -16,8 +16,11 @@ public class SocialLoginRequest {
     @Schema(description = "OAuth Provider", example = "KAKAO", allowableValues = {"KAKAO", "APPLE"})
     private OAuthProvider provider;
 
-    @Schema(description = "OAuth Authorization Code (SDK로부터 받은 인증 코드)", example = "AQBxxx...", required = true)
+    @Schema(description = "OAuth Authorization Code (웹 또는 Android SDK에서 사용)", example = "AQBxxx...", nullable = true)
     private String authCode;
+
+    @Schema(description = "ID Token (iOS SDK에서 직접 받은 경우)", example = "eyJhbGc...", nullable = true)
+    private String idToken;
 
     @Schema(description = """
         OAuth authCode 발급 시 사용한 redirect_uri

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/user/port/out/oauth/client/AppleOAuthClient.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/user/port/out/oauth/client/AppleOAuthClient.java
@@ -116,6 +116,13 @@ public class AppleOAuthClient implements OAuthClient {
     }
 
     @Override
+    public OAuthTokenResponse getTokenFromIdToken(String idToken) {
+        // iOS SDK에서 받은 idToken을 그대로 반환
+        // idToken만 있으면 사용자 정보 추출 가능
+        return new OAuthTokenResponse(null, null, idToken, null, null);
+    }
+
+    @Override
     @Cacheable(value = "oidcPublicKeys", key = "'apple'")
     public OIDCPublicKeyList getPublicKeys() {
         return restClient

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/user/port/out/oauth/client/KakaoOAuthClient.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/user/port/out/oauth/client/KakaoOAuthClient.java
@@ -87,6 +87,13 @@ public class KakaoOAuthClient implements OAuthClient {
     }
 
     @Override
+    public OAuthTokenResponse getTokenFromIdToken(String idToken) {
+        // iOS SDK에서 받은 idToken을 그대로 반환
+        // idToken만 있으면 사용자 정보 추출 가능
+        return new OAuthTokenResponse(null, null, idToken, null, null);
+    }
+
+    @Override
     @Cacheable(value = "oidcPublicKeys", key = "'kakao'")
     public OIDCPublicKeyList getPublicKeys() {
         return restClient

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/user/port/out/oauth/client/OAuthClient.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/user/port/out/oauth/client/OAuthClient.java
@@ -6,6 +6,8 @@ import com.ogd.stockdiary.domain.user.port.out.oauth.OIDCPublicKeyList;
 public interface OAuthClient {
     OAuthTokenResponse getToken(String authCode, String redirectUri);
 
+    OAuthTokenResponse getTokenFromIdToken(String idToken);
+
     OIDCPublicKeyList getPublicKeys();
 
     void unlink(String identifier);

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/user/service/AuthService.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/user/service/AuthService.java
@@ -38,11 +38,21 @@ public class AuthService {
 
     @Transactional
     public AuthResult socialLogin(
-        OAuthProvider provider, String authCode, String redirectUri, String email, String nickname) {
+        OAuthProvider provider, String authCode, String idToken, String redirectUri, String email, String nickname) {
         OAuthClient client = oAuthClientFactory.getClient(provider);
 
-        // 1. 토큰 획득 (redirectUri가 null이면 OAuthClient가 기본값 사용)
-        OAuthTokenResponse tokenResponse = client.getToken(authCode, redirectUri);
+        OAuthTokenResponse tokenResponse;
+
+        // 1. authCode 또는 idToken으로 토큰 획득
+        if (idToken != null && !idToken.isEmpty()) {
+            // iOS SDK 방식: idToken 직접 사용
+            tokenResponse = client.getTokenFromIdToken(idToken);
+        } else if (authCode != null && !authCode.isEmpty()) {
+            // 웹/Android 방식: authCode로 토큰 교환
+            tokenResponse = client.getToken(authCode, redirectUri);
+        } else {
+            throw new IllegalArgumentException("authCode 또는 idToken 중 하나는 필수입니다");
+        }
 
         // 2. 공개키 조회
         OIDCPublicKeyList publicKeys = client.getPublicKeys();


### PR DESCRIPTION
## 📌 관련 이슈
- Jira Ticket: [OGD-44](https://depromeet05.atlassian.net/browse/OGD-44)

## 🔍 PR의 이유
- IOS 에서 authToken 가져오지 못하고바로 accessToken을 가져오기 때문에 로직 변경이 필요

## ✨ 주요 변경사항
- [ ] authCode 또는 idToken을 사용할 수 있도록 필드를 열고 로직 변경

## 📎 참고(선택)
- Provider로 소셜 로그인 나누고있는데 url 로 나눠야 함을 깨달음