### PR TITLE
[OGD-45] 회고 생성 API 리팩토링

### DIFF
--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/principlecheck/dto/request/PrincipleCheckRequest.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/principlecheck/dto/request/PrincipleCheckRequest.java
@@ -22,8 +22,7 @@ public class PrincipleCheckRequest {
     @NotNull(message = "투자원칙 ID는 필수입니다")
     private Long principleId;
 
-    @Schema(description = "투자원칙 준수 상태 (KEPT: 지켰어요, NEUTRAL: 보통이에요, NOT_KEPT: 안지켰어요)", example = "KEPT", allowableValues = {
-        "KEPT", "NEUTRAL", "NOT_KEPT"}, requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(description = "투자원칙 준수 상태 (KEPT: 지켰어요, NEUTRAL: 보통이에요, NOT_KEPT: 안지켰어요)", example = "KEPT", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotNull(message = "투자원칙 준수 상태는 필수입니다")
     private PrincipleCheckStatus status;
 

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/dto/mapper/RetrospectionMapper.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/dto/mapper/RetrospectionMapper.java
@@ -38,8 +38,6 @@ public class RetrospectionMapper {
             request.getVolume(),
             request.getOrderDate(),
             request.getReturnRate(),
-            request.getContent(),
-            request.getEmotion(),
             principleCheckCommands);
     }
 
@@ -64,8 +62,6 @@ public class RetrospectionMapper {
             retrospection.getOrder().getVolume(),
             retrospection.getOrder().getOrderDate(),
             retrospection.getReturnRate(),
-            retrospection.getContent(),
-            retrospection.getEmotion(),
             retrospection.getCreatedAt(),
             retrospection.getUpdatedAt());
     }
@@ -83,9 +79,7 @@ public class RetrospectionMapper {
             command.getSymbol(),
             command.getMarket(),
             order,
-            command.getReturnRate(),
-            command.getContent(),
-            command.getEmotion());
+            command.getReturnRate());
     }
 
     public static GetRetrospectionResponse toGetResponse(
@@ -119,8 +113,6 @@ public class RetrospectionMapper {
             retrospection.getOrder().getVolume(),
             retrospection.getOrder().getOrderDate(),
             retrospection.getReturnRate(),
-            retrospection.getContent(),
-            retrospection.getEmotion(),
             principleCheckResponses,
             memoResponses,
             retrospection.getCreatedAt(),

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/dto/request/CreateRetrospectionRequest.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/dto/request/CreateRetrospectionRequest.java
@@ -11,7 +11,6 @@ import jakarta.validation.constraints.Positive;
 
 import com.ogd.stockdiary.application.principlecheck.dto.request.PrincipleCheckRequest;
 import com.ogd.stockdiary.domain.retrospection.entity.Currency;
-import com.ogd.stockdiary.domain.retrospection.entity.InvestmentEmotion;
 import com.ogd.stockdiary.domain.retrospection.entity.OrderType;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -57,13 +56,7 @@ public class CreateRetrospectionRequest {
     @Schema(description = "수익률", example = "-15.67", requiredMode = RequiredMode.NOT_REQUIRED)
     private Double returnRate;
 
-    @Schema(description = "회고 내용", example = "이번 매도는 시장 상황을 잘 반영한 결정이었다.", requiredMode = RequiredMode.NOT_REQUIRED)
-    private String content;
-
     @Schema(description = "투자원칙 체크 목록", requiredMode = RequiredMode.NOT_REQUIRED)
     @Valid
     private List<PrincipleCheckRequest> principleChecks;
-
-    @Schema(description = "투자 감정", example = "CONFIDENCE", requiredMode = RequiredMode.NOT_REQUIRED)
-    private InvestmentEmotion emotion;
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/dto/response/CreateRetrospectionResponse.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/dto/response/CreateRetrospectionResponse.java
@@ -5,7 +5,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import com.ogd.stockdiary.domain.retrospection.entity.Currency;
-import com.ogd.stockdiary.domain.retrospection.entity.InvestmentEmotion;
 import com.ogd.stockdiary.domain.retrospection.entity.OrderType;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -46,12 +45,6 @@ public class CreateRetrospectionResponse {
 
     @Schema(description = "수익률", example = "-15.67")
     private Double returnRate;
-
-    @Schema(description = "회고 내용", example = "이번 매도는 시장 상황을 잘 반영한 결정이었다.")
-    private String content;
-
-    @Schema(description = "투자 감정", example = "CONFIDENCE")
-    private InvestmentEmotion emotion;
 
     @Schema(description = "생성일시", example = "2025-09-14T10:00:00")
     private LocalDateTime createdAt;

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/dto/response/GetRetrospectionResponse.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/dto/response/GetRetrospectionResponse.java
@@ -7,7 +7,6 @@ import java.util.List;
 
 import com.ogd.stockdiary.domain.principlecheck.entity.PrincipleCheckStatus;
 import com.ogd.stockdiary.domain.retrospection.entity.Currency;
-import com.ogd.stockdiary.domain.retrospection.entity.InvestmentEmotion;
 import com.ogd.stockdiary.domain.retrospection.entity.OrderType;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -48,12 +47,6 @@ public class GetRetrospectionResponse {
 
     @Schema(description = "수익률", example = "-15.67")
     private Double returnRate;
-
-    @Schema(description = "회고 내용", example = "이번 매도는 시장 상황을 잘 반영한 결정이었다.")
-    private String content;
-
-    @Schema(description = "투자 감정", example = "CONFIDENCE")
-    private InvestmentEmotion emotion;
 
     @Schema(description = "투자 원칙 목록")
     private List<PrincipleCheckResponse> principleChecks;

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/retrospection/entity/Retrospection.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/retrospection/entity/Retrospection.java
@@ -6,8 +6,6 @@ import jakarta.persistence.Column;
 import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
@@ -49,13 +47,6 @@ public class Retrospection {
 
     private Double returnRate;
 
-    @Column(columnDefinition = "TEXT")
-    private String content;
-
-    @Enumerated(EnumType.STRING)
-    @Column(name = "emotion")
-    private InvestmentEmotion emotion;
-
     @Column(updatable = false)
     private LocalDateTime createdAt;
 
@@ -77,15 +68,11 @@ public class Retrospection {
         String symbol,
         String market,
         Order order,
-        Double returnRate,
-        String content,
-        InvestmentEmotion emotion) {
+        Double returnRate) {
         this.user = user;
         this.symbol = symbol;
         this.market = market;
         this.order = order;
         this.returnRate = returnRate;
-        this.content = content;
-        this.emotion = emotion;
     }
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/retrospection/port/in/CreateRetrospectionCommand.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/retrospection/port/in/CreateRetrospectionCommand.java
@@ -6,7 +6,6 @@ import java.util.List;
 
 import com.ogd.stockdiary.domain.principlecheck.dto.PrincipleCheckCommand;
 import com.ogd.stockdiary.domain.retrospection.entity.Currency;
-import com.ogd.stockdiary.domain.retrospection.entity.InvestmentEmotion;
 import com.ogd.stockdiary.domain.retrospection.entity.OrderType;
 
 import lombok.AllArgsConstructor;
@@ -25,7 +24,5 @@ public class CreateRetrospectionCommand {
     private final Integer volume;
     private final LocalDate orderDate;
     private final Double returnRate;
-    private final String content;
-    private final InvestmentEmotion emotion;
     private final List<PrincipleCheckCommand> principleChecks;
 }


### PR DESCRIPTION
## 📌 관련 이슈
- Jira Ticket: [OGD-45](https://depromeet05.atlassian.net/browse/OGD-45)

## 🔍 PR의 이유
  - 회고 생성 API에서 사용하지 않는 `content`와 `emotion` 필드 제거

  ## ✨ 주요 변경사항
  - [x] Retrospection 엔티티에서 `content`, `emotion` 필드 제거
  - [x] CreateRetrospectionCommand에서 `content`, `emotion` 파라미터
  제거
  - [x] RetrospectionMapper에서 관련 매핑 코드 제거
  - [x] CreateRetrospectionResponse, GetRetrospectionResponse에서
  해당 필드 제거

  ## 📎 참고