### PR TITLE
[OGD-46] 회고 조회 시 투자그룹으로 묶어서 투자원칙 내려주기

### DIFF
--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/dto/mapper/RetrospectionMapper.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/dto/mapper/RetrospectionMapper.java
@@ -1,8 +1,10 @@
 package com.ogd.stockdiary.application.retrospection.dto.mapper;
 
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.ogd.stockdiary.application.principlecheck.dto.request.PrincipleCheckRequest;
 import com.ogd.stockdiary.application.retrospection.dto.request.CreateRetrospectionRequest;
@@ -11,6 +13,7 @@ import com.ogd.stockdiary.application.retrospection.dto.response.GetRetrospectio
 import com.ogd.stockdiary.application.retrospection.dto.response.MemoResponse;
 import com.ogd.stockdiary.domain.principlecheck.dto.PrincipleCheckCommand;
 import com.ogd.stockdiary.domain.principlecheck.entity.PrincipleCheck;
+import com.ogd.stockdiary.domain.principlegroup.entity.PrincipleGroup;
 import com.ogd.stockdiary.domain.retrospection.entity.Memo;
 import com.ogd.stockdiary.domain.retrospection.entity.Order;
 import com.ogd.stockdiary.domain.retrospection.entity.Retrospection;
@@ -88,14 +91,37 @@ public class RetrospectionMapper {
         Map<Long, List<String>> imageUrlsMap,
         Map<Long, List<String>> linksMap,
         List<Memo> memos) {
-        List<GetRetrospectionResponse.PrincipleCheckResponse> principleCheckResponses = principleChecks.stream()
-            .map(pc -> new GetRetrospectionResponse.PrincipleCheckResponse(
-                pc.getPrinciple().getId(),
-                pc.getPrinciple().getPrinciple(),
-                pc.getStatus(),
-                pc.getReason(),
-                imageUrlsMap.getOrDefault(pc.getId(), Collections.emptyList()),
-                linksMap.getOrDefault(pc.getId(), Collections.emptyList())))
+        // PrincipleCheck를 PrincipleGroup으로 그룹핑
+        Map<PrincipleGroup, List<PrincipleCheck>> groupedChecks = principleChecks.stream()
+            .collect(Collectors.groupingBy(pc -> pc.getPrinciple().getPrincipleGroup()));
+
+        // PrincipleGroupWithChecksResponse 리스트 생성 (groupId 순서로 정렬)
+        List<GetRetrospectionResponse.PrincipleGroupWithChecksResponse> principleCheckGroups = groupedChecks.entrySet()
+            .stream()
+            .map(entry -> {
+                PrincipleGroup group = entry.getKey();
+                List<PrincipleCheck> checks = entry.getValue();
+
+                // 그룹 내 원칙 체크들을 principleId 순서로 정렬하여 응답 생성
+                List<GetRetrospectionResponse.PrincipleCheckResponse> checkResponses = checks.stream()
+                    .sorted(Comparator.comparing(pc -> pc.getPrinciple().getId()))
+                    .map(pc -> new GetRetrospectionResponse.PrincipleCheckResponse(
+                        pc.getPrinciple().getId(),
+                        pc.getPrinciple().getPrinciple(),
+                        pc.getStatus(),
+                        pc.getReason(),
+                        imageUrlsMap.getOrDefault(pc.getId(), Collections.emptyList()),
+                        linksMap.getOrDefault(pc.getId(), Collections.emptyList())))
+                    .toList();
+
+                return new GetRetrospectionResponse.PrincipleGroupWithChecksResponse(
+                    group.getId(),
+                    group.getGroupName(),
+                    group.getThumbnail(),
+                    group.getPrincipleType(),
+                    checkResponses);
+            })
+            .sorted(Comparator.comparing(GetRetrospectionResponse.PrincipleGroupWithChecksResponse::getGroupId))
             .toList();
 
         List<MemoResponse> memoResponses = memos.stream()
@@ -113,7 +139,7 @@ public class RetrospectionMapper {
             retrospection.getOrder().getVolume(),
             retrospection.getOrder().getOrderDate(),
             retrospection.getReturnRate(),
-            principleCheckResponses,
+            principleCheckGroups,
             memoResponses,
             retrospection.getCreatedAt(),
             retrospection.getUpdatedAt());

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/dto/response/GetRetrospectionResponse.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/dto/response/GetRetrospectionResponse.java
@@ -5,6 +5,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.ogd.stockdiary.domain.investmentprinciple.entity.PrincipleType;
 import com.ogd.stockdiary.domain.principlecheck.entity.PrincipleCheckStatus;
 import com.ogd.stockdiary.domain.retrospection.entity.Currency;
 import com.ogd.stockdiary.domain.retrospection.entity.OrderType;
@@ -48,8 +49,8 @@ public class GetRetrospectionResponse {
     @Schema(description = "수익률", example = "-15.67")
     private Double returnRate;
 
-    @Schema(description = "투자 원칙 목록")
-    private List<PrincipleCheckResponse> principleChecks;
+    @Schema(description = "투자 원칙 그룹 목록")
+    private List<PrincipleGroupWithChecksResponse> principleCheckGroups;
 
     @Schema(description = "메모 목록")
     private List<MemoResponse> memos;
@@ -59,6 +60,27 @@ public class GetRetrospectionResponse {
 
     @Schema(description = "수정일시", example = "2025-09-14T10:00:00")
     private LocalDateTime updatedAt;
+
+    @AllArgsConstructor
+    @Getter
+    @Schema(description = "투자 원칙 그룹 정보")
+    public static class PrincipleGroupWithChecksResponse {
+
+        @Schema(description = "투자 원칙 그룹 ID", example = "1")
+        private Long groupId;
+
+        @Schema(description = "그룹명", example = "리스크 관리")
+        private String groupName;
+
+        @Schema(description = "썸네일", example = "🔥")
+        private String thumbnail;
+
+        @Schema(description = "원칙 타입", example = "BUY")
+        private PrincipleType principleType;
+
+        @Schema(description = "투자 원칙 체크 목록")
+        private List<PrincipleCheckResponse> principleChecks;
+    }
 
     @AllArgsConstructor
     @Getter


### PR DESCRIPTION
## 📌 관련 이슈
- Jira Ticket: [OGD-46](https://depromeet05.atlassian.net/browse/OGD-46)

## 🔍 PR의 이유
- ex) 외부 서비스 호출 시 기본 설정으로는 Redirect를 따르지 않아 요청 실패 발생

## ✨ 주요 변경사항
- [ ] ex) FeignClient 옵션에 Redirect 허용 설정 추가
- [ ] ex) 기타 설정 값 정리 및 주석 추가 (선택)

## 📎 참고(선택)
- ex) 관련 문서, 이슈 링크 등이 있다면 작성해주세요.