### PR TITLE
[OGD-49] 파일사이즈제한풀기

### DIFF
--- a/stock-diary/src/main/resources/application.yml
+++ b/stock-diary/src/main/resources/application.yml
@@ -29,6 +29,10 @@ cloud:
     # AWS S3로 전환시: endpoint를 제거하고 region만 사용 (예: ap-northeast-2)
 
 spring:
+  servlet:
+    multipart:
+      max-file-size: 30MB
+      max-request-size: 30MB
   jpa:
     hibernate:
       ddl-auto: update
@@ -41,7 +45,7 @@ spring:
   ai:
     openai:
       api-key: ${OPENAI_API_KEY}
-  
+
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: ${DB_URL}


### PR DESCRIPTION
## 📌 관련 이슈
- Jira Ticket: [OGD-49](https://depromeet05.atlassian.net/browse/OGD-49)

## 🔍 PR의 이유
- 파일업로드 사이즈제한으로 이미지업로드 불가

## ✨ 주요 변경사항
- [ ] 서블릿 옵션 사항 30메가로 풀기

## 📎 참고(선택)
- ex) 관련 문서, 이슈 링크 등이 있다면 작성해주세요.