### PR TITLE
fix: 종목별 회고 목록 조회 API 에서 companyName 으로 회고 목록 그룹핑

### DIFF
--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/dto/response/MarketGroupResponse.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/dto/response/MarketGroupResponse.java
@@ -3,6 +3,6 @@ package com.ogd.stockdiary.application.retrospection.dto.response;
 import java.util.List;
 
 public record MarketGroupResponse(
-    String market,
+    String companyName,
     List<RetrospectionDetailResponse> retrospections) {
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/service/RetrospectionService.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/service/RetrospectionService.java
@@ -37,6 +37,8 @@ import com.ogd.stockdiary.domain.retrospection.port.in.GetRetrospectionCommand;
 import com.ogd.stockdiary.domain.retrospection.port.in.GetRetrospectionUseCase;
 import com.ogd.stockdiary.domain.retrospection.port.out.MemoRepository;
 import com.ogd.stockdiary.domain.retrospection.port.out.RetrospectionRepository;
+import com.ogd.stockdiary.domain.stock.entity.Stock;
+import com.ogd.stockdiary.domain.stock.repository.StockRepository;
 import com.ogd.stockdiary.domain.user.entity.User;
 import com.ogd.stockdiary.exception.ApplicationException;
 
@@ -62,6 +64,7 @@ public class RetrospectionService
     private final JpaPrincipleCheckLinkRepository principleCheckLinkRepository;
     private final ImageUseCase imageUseCase;
     private final MemoRepository memoRepository;
+    private final StockRepository stockRepository;
 
     @Override
     @Transactional
@@ -194,15 +197,27 @@ public class RetrospectionService
     @Override
     public List<MarketGroupResponse> getAllRetrospections(GetRetrospectionCommand command) {
 
-        // 회고 디비에서 조회
-        List<Retrospection> retrospection = retrospectionRepository.findAllByUserId(command.userId());
+        // 사용자의 모든 회고 조회
+        List<Retrospection> retrospections = retrospectionRepository.findAllByUserId(command.userId());
 
-        // market 기준 그룹화
-        Map<String, List<Retrospection>> retrospectionsByMarket = retrospection.stream()
-            .collect(Collectors.groupingBy(Retrospection::getMarket));
+        // 회고에서 symbol 목록 추출해서 stock 정보 조회
+        List<String> symbol = retrospections.stream().map(Retrospection::getSymbol).distinct().toList();
+        List<Stock> stocks = stockRepository.findAllByCodeIn(symbol);
+
+        // stock 정보를 Map 으로 변환
+        Map<String, String> stockByCompanyName = stocks.stream()
+            .collect(Collectors.toMap(
+                stock -> (stock.getCode()), // 키: stock의 code
+                Stock::getCompanyName));
+
+        // companyName 기준 회고 그룹화
+        Map<String, List<Retrospection>> retrospectionsByCompanyName = retrospections.stream()
+            .collect(Collectors.groupingBy(retrospection
+            // 키: retrospection 의 symbol
+            -> stockByCompanyName.getOrDefault(retrospection.getSymbol(), retrospection.getSymbol())));
 
         // 응답 DTO 로 변환
-        return retrospectionsByMarket.entrySet().stream()
+        return retrospectionsByCompanyName.entrySet().stream()
             .map(entry -> {
                 List<RetrospectionDetailResponse> detailResponses = entry.getValue().stream()
                     .map(RetrospectionDetailResponse::fromEntity)

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/stock/repository/JpaStockRepository.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/stock/repository/JpaStockRepository.java
@@ -20,4 +20,7 @@ public interface JpaStockRepository extends CrudRepository<Stock, Long> {
     @Query("SELECT s FROM Stock s WHERE s.companyName LIKE %:companyName% AND s.id < :cursor ORDER BY s.id DESC")
     List<Stock> findByCompanyNameLikeOrderByIdDesc(
         String companyName, Integer cursor, Pageable pageable);
+
+    @Query("SELECT s FROM Stock s WHERE s.code IN :codes")
+    List<Stock> findAllByCodeIn(List<String> codes);
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/stock/repository/StockRepositoryImpl.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/stock/repository/StockRepositoryImpl.java
@@ -39,4 +39,9 @@ public class StockRepositoryImpl implements StockRepository {
 
         return new SliceContent<>(content, id);
     }
+
+    @Override
+    public List<Stock> findAllByCodeIn(List<String> codes) {
+        return jpaStockRepository.findAllByCodeIn(codes);
+    }
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/stock/repository/StockRepository.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/stock/repository/StockRepository.java
@@ -9,4 +9,7 @@ public interface StockRepository {
     List<Stock> findByCompanyName(String companyName);
 
     SliceContent<Stock> findByCompanyNameSlice(String nextCursor, String companyName, int size);
+
+    List<Stock> findAllByCodeIn(List<String> codes);
+
 }


### PR DESCRIPTION
## 🔍 PR의 이유
- ex) 외부 서비스 호출 시 기본 설정으로는 Redirect를 따르지 않아 요청 실패 발생

## ✨ 주요 변경사항
- [ ] ex) FeignClient 옵션에 Redirect 허용 설정 추가
- [ ] ex) 기타 설정 값 정리 및 주석 추가 (선택)

## 📎 참고(선택)
- ex) 관련 문서, 이슈 링크 등이 있다면 작성해주세요.
