### PR TITLE
fix. 투자 그룹 조회 시, id로 조회하고 userId를 애플리케이션에서 비교하기

### DIFF
--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/principlegroup/repository/PrincipleGroupRepositoryImpl.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/principlegroup/repository/PrincipleGroupRepositoryImpl.java
@@ -43,6 +43,11 @@ public class PrincipleGroupRepositoryImpl implements PrincipleGroupRepository {
     }
 
     @Override
+    public Optional<PrincipleGroup> findById(Long groupId) {
+        return jpaPrincipleGroupRepository.findById(groupId);
+    }
+
+    @Override
     public Optional<PrincipleGroup> findByIdAndUserId(Long groupId, Long userId) {
         return jpaPrincipleGroupRepository.findByIdAndUserId(groupId, userId);
     }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlegroup/port/out/PrincipleGroupRepository.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlegroup/port/out/PrincipleGroupRepository.java
@@ -18,6 +18,8 @@ public interface PrincipleGroupRepository {
 
     PrincipleGroup save(PrincipleGroup principleGroup);
 
+    Optional<PrincipleGroup> findById(Long groupId);
+
     Optional<PrincipleGroup> findByIdAndUserId(Long groupId, Long userId);
 
     void deleteByIdAndUserId(Long groupId, Long userId);

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlegroup/service/PrincipleGroupService.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlegroup/service/PrincipleGroupService.java
@@ -92,11 +92,20 @@ public class PrincipleGroupService implements PrincipleGroupUseCase {
     @Override
     @Transactional(readOnly = true)
     public PrincipleGroup getPrincipleGroupById(Long groupId, Long userId) {
-        return principleGroupRepository
-            .findByIdAndUserId(groupId, userId)
+        PrincipleGroup principleGroup = principleGroupRepository
+            .findById(groupId)
             .orElseThrow(
                 () -> new ApplicationException(
                     CodeEnum.FRS_003, "투자원칙 그룹을 찾을 수 없습니다: " + groupId));
+
+        // 추천 및 기본 투자 그룹은 모든 사용자가 접근 가능
+        if (principleGroup.getGroupType() == PrincipleGroupType.USER
+            && !principleGroup.getUser().getId().equals(userId)) {
+            throw new ApplicationException(
+                CodeEnum.FRS_003, "해당 유저( " + userId + ")의 투자원칙 그룹을 찾을 수 없습니다: " + groupId);
+        }
+
+        return principleGroup;
     }
 
     @Override


### PR DESCRIPTION
## 📌 관련 이슈
- Jira Ticket: [OGD-51](https://depromeet05.atlassian.net/browse/OGD-51)

## 🔍 PR의 이유
- ex) 외부 서비스 호출 시 기본 설정으로는 Redirect를 따르지 않아 요청 실패 발생

## ✨ 주요 변경사항
- [ ] ex) FeignClient 옵션에 Redirect 허용 설정 추가
- [ ] ex) 기타 설정 값 정리 및 주석 추가 (선택)

## 📎 참고(선택)
- ex) 관련 문서, 이슈 링크 등이 있다면 작성해주세요.