### PR TITLE
[OGD-56] 회고 조회 API 수정

### DIFF
--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/report/repository/FeedbackRepositoryImpl.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/report/repository/FeedbackRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.ogd.stockdiary.application.report.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.stereotype.Component;
 
@@ -25,5 +26,10 @@ public class FeedbackRepositoryImpl implements FeedbackRepository {
 
     public List<Feedback> findAllByUserId(Long userId) {
         return jpaFeedbackRepository.findAllByUserId(userId);
+    }
+
+    @Override
+    public Optional<Feedback> findByRetrospectionId(Long retrospectionId) {
+        return jpaFeedbackRepository.findByRetrospectionId(retrospectionId);
     }
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/report/repository/JpaFeedbackRepository.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/report/repository/JpaFeedbackRepository.java
@@ -1,6 +1,7 @@
 package com.ogd.stockdiary.application.report.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,4 +10,6 @@ import com.ogd.stockdiary.domain.report.entity.Feedback;
 public interface JpaFeedbackRepository extends JpaRepository<Feedback, Long> {
 
     List<Feedback> findAllByUserId(Long userId);
+
+    Optional<Feedback> findByRetrospectionId(Long retrospectionId);
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/dto/mapper/MemoMapper.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/dto/mapper/MemoMapper.java
@@ -18,6 +18,7 @@ public class MemoMapper {
     public static MemoResponse toResponse(Memo memo) {
         return new MemoResponse(
             memo.getId(),
-            memo.getContent());
+            memo.getContent(),
+            memo.getCreatedAt());
     }
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/dto/mapper/RetrospectionMapper.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/dto/mapper/RetrospectionMapper.java
@@ -14,11 +14,13 @@ import com.ogd.stockdiary.application.retrospection.dto.response.MemoResponse;
 import com.ogd.stockdiary.domain.principlecheck.dto.PrincipleCheckCommand;
 import com.ogd.stockdiary.domain.principlecheck.entity.PrincipleCheck;
 import com.ogd.stockdiary.domain.principlegroup.entity.PrincipleGroup;
+import com.ogd.stockdiary.domain.report.entity.Feedback;
 import com.ogd.stockdiary.domain.retrospection.entity.Memo;
 import com.ogd.stockdiary.domain.retrospection.entity.Order;
 import com.ogd.stockdiary.domain.retrospection.entity.Retrospection;
 import com.ogd.stockdiary.domain.retrospection.port.in.CreateRetrospectionCommand;
 import com.ogd.stockdiary.domain.retrospection.port.in.GetRetrospectionCommand;
+import com.ogd.stockdiary.domain.stock.entity.Stock;
 import com.ogd.stockdiary.domain.user.entity.User;
 
 public class RetrospectionMapper {
@@ -90,13 +92,16 @@ public class RetrospectionMapper {
         List<PrincipleCheck> principleChecks,
         Map<Long, List<String>> imageUrlsMap,
         Map<Long, List<String>> linksMap,
-        List<Memo> memos) {
+        List<Memo> memos,
+        Stock stock,
+        String companyLogoUrl,
+        Feedback feedback) {
         // PrincipleCheck를 PrincipleGroup으로 그룹핑
         Map<PrincipleGroup, List<PrincipleCheck>> groupedChecks = principleChecks.stream()
             .collect(Collectors.groupingBy(pc -> pc.getPrinciple().getPrincipleGroup()));
 
-        // PrincipleGroupWithChecksResponse 리스트 생성 (groupId 순서로 정렬)
-        List<GetRetrospectionResponse.PrincipleGroupWithChecksResponse> principleCheckGroups = groupedChecks.entrySet()
+        // PrincipleGroupWithChecksResponse 생성 (첫 번째 그룹만 반환)
+        GetRetrospectionResponse.PrincipleGroupWithChecksResponse principleCheckGroup = groupedChecks.entrySet()
             .stream()
             .map(entry -> {
                 PrincipleGroup group = entry.getKey();
@@ -122,7 +127,8 @@ public class RetrospectionMapper {
                     checkResponses);
             })
             .sorted(Comparator.comparing(GetRetrospectionResponse.PrincipleGroupWithChecksResponse::getGroupId))
-            .toList();
+            .findFirst()
+            .orElse(null);
 
         List<MemoResponse> memoResponses = memos.stream()
             .map(MemoMapper::toResponse)
@@ -133,13 +139,16 @@ public class RetrospectionMapper {
             retrospection.getUser().getId(),
             retrospection.getSymbol(),
             retrospection.getMarket(),
+            stock != null ? stock.getCompanyName() : null,
+            companyLogoUrl,
             retrospection.getOrder().getOrderType(),
             retrospection.getOrder().getPrice(),
             retrospection.getOrder().getCurrency(),
             retrospection.getOrder().getVolume(),
             retrospection.getOrder().getOrderDate(),
             retrospection.getReturnRate(),
-            principleCheckGroups,
+            feedback != null ? feedback.getTitle() : null,
+            principleCheckGroup,
             memoResponses,
             retrospection.getCreatedAt(),
             retrospection.getUpdatedAt());

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/dto/response/GetRetrospectionResponse.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/dto/response/GetRetrospectionResponse.java
@@ -31,6 +31,12 @@ public class GetRetrospectionResponse {
     @Schema(description = "시장 정보", example = "NASDAQ")
     private String market;
 
+    @Schema(description = "기업명", example = "삼성전자")
+    private String companyName;
+
+    @Schema(description = "기업 로고 URL", example = "https://example.com/logo.png")
+    private String companyLogo;
+
     @Schema(description = "주문 타입", example = "SELL")
     private OrderType orderType;
 
@@ -49,8 +55,11 @@ public class GetRetrospectionResponse {
     @Schema(description = "수익률", example = "-15.67")
     private Double returnRate;
 
-    @Schema(description = "투자 원칙 그룹 목록")
-    private List<PrincipleGroupWithChecksResponse> principleCheckGroups;
+    @Schema(description = "피드백 뱃지", example = "훌륭해요!")
+    private String badge;
+
+    @Schema(description = "투자 원칙 그룹")
+    private PrincipleGroupWithChecksResponse principleCheckGroup;
 
     @Schema(description = "메모 목록")
     private List<MemoResponse> memos;

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/dto/response/MemoResponse.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/dto/response/MemoResponse.java
@@ -1,5 +1,7 @@
 package com.ogd.stockdiary.application.retrospection.dto.response;
 
+import java.time.LocalDateTime;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -14,4 +16,7 @@ public class MemoResponse {
 
     @Schema(description = "메모 내용", example = "이번 거래에서 감정적으로 판단한 부분이 있었다.")
     private String content;
+
+    @Schema(description = "메모 생성일시", example = "2025-09-14T10:00:00")
+    private LocalDateTime createdAt;
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/service/RetrospectionService.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/retrospection/service/RetrospectionService.java
@@ -3,6 +3,7 @@ package com.ogd.stockdiary.application.retrospection.service;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
@@ -28,6 +29,8 @@ import com.ogd.stockdiary.domain.principlecheck.dto.PrincipleCheckCommand;
 import com.ogd.stockdiary.domain.principlecheck.entity.PrincipleCheck;
 import com.ogd.stockdiary.domain.principlecheck.entity.PrincipleCheckLink;
 import com.ogd.stockdiary.domain.principlecheck.port.out.PrincipleCheckRepository;
+import com.ogd.stockdiary.domain.report.entity.Feedback;
+import com.ogd.stockdiary.domain.report.port.out.FeedbackRepository;
 import com.ogd.stockdiary.domain.retrospection.entity.Memo;
 import com.ogd.stockdiary.domain.retrospection.entity.Retrospection;
 import com.ogd.stockdiary.domain.retrospection.port.in.*;
@@ -37,6 +40,7 @@ import com.ogd.stockdiary.domain.retrospection.port.in.GetRetrospectionCommand;
 import com.ogd.stockdiary.domain.retrospection.port.in.GetRetrospectionUseCase;
 import com.ogd.stockdiary.domain.retrospection.port.out.MemoRepository;
 import com.ogd.stockdiary.domain.retrospection.port.out.RetrospectionRepository;
+import com.ogd.stockdiary.domain.stock.entity.Market;
 import com.ogd.stockdiary.domain.stock.entity.Stock;
 import com.ogd.stockdiary.domain.stock.repository.StockRepository;
 import com.ogd.stockdiary.domain.user.entity.User;
@@ -65,6 +69,7 @@ public class RetrospectionService
     private final ImageUseCase imageUseCase;
     private final MemoRepository memoRepository;
     private final StockRepository stockRepository;
+    private final FeedbackRepository feedbackRepository;
 
     @Override
     @Transactional
@@ -173,7 +178,28 @@ public class RetrospectionService
         // 메모 목록 조회 (최신순 정렬)
         List<Memo> memos = memoRepository.findByRetrospectionIdOrderByIdDesc(retrospectionId);
 
-        return RetrospectionMapper.toGetResponse(retrospection, principleChecks, imageUrlsMap, linksMap, memos);
+        // Stock 조회 (symbol과 market으로)
+        Stock stock = null;
+        String companyLogoUrl = null;
+        try {
+            Market market = Market.valueOf(retrospection.getMarket());
+            Optional<Stock> stockOptional = stockRepository.findByCodeAndMarket(retrospection.getSymbol(), market);
+            stock = stockOptional.orElse(null);
+
+            // Stock의 logo가 있으면 URL 생성
+            if (stock != null && stock.getLogo() != null) {
+                companyLogoUrl = imageUseCase.getDownloadUrl(stock.getLogo());
+            }
+        } catch (IllegalArgumentException e) {
+            // Market enum 변환 실패 시 stock은 null로 유지
+        }
+
+        // Feedback 조회
+        Optional<Feedback> feedbackOptional = feedbackRepository.findByRetrospectionId(retrospectionId);
+        Feedback feedback = feedbackOptional.orElse(null);
+
+        return RetrospectionMapper.toGetResponse(retrospection, principleChecks, imageUrlsMap, linksMap, memos, stock,
+            companyLogoUrl, feedback);
     }
 
     private List<String> getImageUrls(Long principleCheckId) {
@@ -207,7 +233,7 @@ public class RetrospectionService
         // stock 정보를 Map 으로 변환
         Map<String, String> stockByCompanyName = stocks.stream()
             .collect(Collectors.toMap(
-                stock -> (stock.getCode()), // 키: stock의 code
+                Stock::getCode, // 키: stock의 code
                 Stock::getCompanyName));
 
         // companyName 기준 회고 그룹화

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/stock/repository/JpaStockRepository.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/stock/repository/JpaStockRepository.java
@@ -1,12 +1,14 @@
 package com.ogd.stockdiary.application.stock.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+import com.ogd.stockdiary.domain.stock.entity.Market;
 import com.ogd.stockdiary.domain.stock.entity.Stock;
 
 @RequestMapping
@@ -26,4 +28,7 @@ public interface JpaStockRepository extends CrudRepository<Stock, Long> {
 
     @Query("SELECT s FROM Stock s WHERE s.code = :code")
     Stock findByCode(String code);
+
+    @Query("SELECT s FROM Stock s WHERE s.code = :code AND s.market = :market")
+    Optional<Stock> findByCodeAndMarket(String code, Market market);
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/stock/repository/StockRepositoryImpl.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/stock/repository/StockRepositoryImpl.java
@@ -1,11 +1,13 @@
 package com.ogd.stockdiary.application.stock.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
 
 import com.ogd.stockdiary.common.httpresponse.SliceContent;
+import com.ogd.stockdiary.domain.stock.entity.Market;
 import com.ogd.stockdiary.domain.stock.entity.Stock;
 import com.ogd.stockdiary.domain.stock.repository.StockRepository;
 
@@ -48,6 +50,11 @@ public class StockRepositoryImpl implements StockRepository {
     @Override
     public Stock findByCode(String code) {
         return jpaStockRepository.findByCode(code);
+    }
+
+    @Override
+    public Optional<Stock> findByCodeAndMarket(String code, Market market) {
+        return jpaStockRepository.findByCodeAndMarket(code, market);
     }
 
     @Override

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/report/port/out/FeedbackRepository.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/report/port/out/FeedbackRepository.java
@@ -1,6 +1,7 @@
 package com.ogd.stockdiary.domain.report.port.out;
 
 import java.util.List;
+import java.util.Optional;
 
 import com.ogd.stockdiary.domain.report.entity.Feedback;
 
@@ -11,4 +12,6 @@ public interface FeedbackRepository {
     void deleteById(Long id);
 
     List<Feedback> findAllByUserId(Long userId);
+
+    Optional<Feedback> findByRetrospectionId(Long retrospectionId);
 }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/stock/repository/StockRepository.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/stock/repository/StockRepository.java
@@ -1,8 +1,10 @@
 package com.ogd.stockdiary.domain.stock.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import com.ogd.stockdiary.common.httpresponse.SliceContent;
+import com.ogd.stockdiary.domain.stock.entity.Market;
 import com.ogd.stockdiary.domain.stock.entity.Stock;
 
 public interface StockRepository {
@@ -13,6 +15,8 @@ public interface StockRepository {
     List<Stock> findAllByCodeIn(List<String> codes);
 
     Stock findByCode(String code);
+
+    Optional<Stock> findByCodeAndMarket(String code, Market market);
 
     Stock save(Stock stock);
 


### PR DESCRIPTION
## 📌 관련 이슈
- Jira Ticket: [OGD-56](https://depromeet05.atlassian.net/browse/OGD-56)

- 회사명
- 뱃지
- memo createdAt 추가
- 회사 썸네일 이미지
- 투자원칙 그룹 1개만 내려주기

## 🔍 PR의 이유
- ex) 외부 서비스 호출 시 기본 설정으로는 Redirect를 따르지 않아 요청 실패 발생

## ✨ 주요 변경사항
- [ ] ex) FeignClient 옵션에 Redirect 허용 설정 추가
- [ ] ex) 기타 설정 값 정리 및 주석 추가 (선택)

## 📎 참고(선택)
- ex) 관련 문서, 이슈 링크 등이 있다면 작성해주세요.