### PR TITLE
[OGD-54] 애플회원탈퇴 authCode 원복

### DIFF
--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/user/controller/UserController.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/user/controller/UserController.java
@@ -51,9 +51,9 @@ public class UserController {
     @DeleteMapping
     public HttpApiResponse<Void> withdraw(
         @AuthenticationPrincipal AuthenticatedUser authenticatedUser,
-        @RequestParam String authCode
-    ) {
-        log.info("User withdrawal requested - userId: {}", authenticatedUser.getUserId());
+        @RequestParam(required = false) String authCode) {
+        log.info("User withdrawal requested - userId: {}, authCode provided: {}",
+            authenticatedUser.getUserId(), authCode != null);
         authService.withdrawUser(authenticatedUser.getUserId());
         return HttpApiResponse.ok();
     }

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/user/controller/UserController.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/user/controller/UserController.java
@@ -50,7 +50,9 @@ public class UserController {
     })
     @DeleteMapping
     public HttpApiResponse<Void> withdraw(
-        @AuthenticationPrincipal AuthenticatedUser authenticatedUser) {
+        @AuthenticationPrincipal AuthenticatedUser authenticatedUser,
+        @RequestParam String authCode
+    ) {
         log.info("User withdrawal requested - userId: {}", authenticatedUser.getUserId());
         authService.withdrawUser(authenticatedUser.getUserId());
         return HttpApiResponse.ok();


### PR DESCRIPTION
## 📌 관련 이슈
- Jira Ticket: [OGD-54-fix-3](https://depromeet05.atlassian.net/browse/OGD-54-fix-3)

## 🔍 PR의 이유
- ex) 외부 서비스 호출 시 기본 설정으로는 Redirect를 따르지 않아 요청 실패 발생

## ✨ 주요 변경사항
- [ ] ex) FeignClient 옵션에 Redirect 허용 설정 추가
- [ ] ex) 기타 설정 값 정리 및 주석 추가 (선택)

## 📎 참고(선택)
- ex) 관련 문서, 이슈 링크 등이 있다면 작성해주세요.