### PR TITLE
[FEATURE] 멀티 에이전트 구성 

### DIFF
--- a/stock-diary/build.gradle
+++ b/stock-diary/build.gradle
@@ -77,6 +77,9 @@ dependencies {
     annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
     annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 
+    // 캐시
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+
     compileOnly 'org.projectlombok:lombok'
 
     runtimeOnly 'com.h2database:h2'

--- a/stock-diary/src/main/java/com/ogd/stockdiary/StockDiaryApplication.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/StockDiaryApplication.java
@@ -3,8 +3,12 @@ package com.ogd.stockdiary;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication(exclude = {SecurityAutoConfiguration.class})
+@EnableAsync
+@EnableCaching
 public class StockDiaryApplication {
 
     public static void main(String[] args) {

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/config/AsyncConfig.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/config/AsyncConfig.java
@@ -1,0 +1,28 @@
+package com.ogd.stockdiary.application.config;
+
+import java.util.concurrent.Executor;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "threadPoolTaskExecutor")
+    public Executor threadPoolTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+
+        // 코어 풀과 Max 풀 크기를 I/O 바운드에 맞게 늘리기
+        executor.setCorePoolSize(16);
+
+        executor.setMaxPoolSize(32);
+        executor.setQueueCapacity(500);
+        executor.initialize();
+
+        return executor;
+
+    }
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/report/dto/Response/FundamentalAnalysis.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/report/dto/Response/FundamentalAnalysis.java
@@ -1,0 +1,13 @@
+package com.ogd.stockdiary.application.report.dto.Response;
+
+public record FundamentalAnalysis(
+    String earnings,
+    String peRatio,
+    String sectorTrend,
+    String macroFactors,
+    String recommendation) {
+    public static FundamentalAnalysis onCreate(String earnings, String peRatio, String sectorTrend, String macroFactors,
+        String recommendation) {
+        return new FundamentalAnalysis(earnings, peRatio, sectorTrend, macroFactors, recommendation);
+    }
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/report/dto/Response/MarketData.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/report/dto/Response/MarketData.java
@@ -1,0 +1,13 @@
+package com.ogd.stockdiary.application.report.dto.Response;
+
+public record MarketData(
+    String symbol,
+    String trend1w,
+    String trend1m,
+    String trend6m
+
+) {
+    public static MarketData onCreate(String symbol, String trend1w, String trend1m, String trend6m) {
+        return new MarketData(symbol, trend1w, trend1m, trend6m);
+    }
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/report/dto/Response/Research.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/report/dto/Response/Research.java
@@ -1,0 +1,17 @@
+package com.ogd.stockdiary.application.report.dto.Response;
+
+public record Research(
+    String marketContext,
+    String investmentThesis,
+    String riskFactors,
+    String priceTarget,
+    String technicalSummary,
+    String fundamentalSummary
+
+) {
+    public static Research onCreate(String marketContext, String investmentThesis, String riskFactors,
+        String priceTarget, String technicalSummary, String fundamentalSummary) {
+        return new Research(marketContext, investmentThesis, riskFactors, priceTarget, technicalSummary,
+            fundamentalSummary);
+    }
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/report/dto/Response/TechnicalAnalysis.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/report/dto/Response/TechnicalAnalysis.java
@@ -1,0 +1,15 @@
+package com.ogd.stockdiary.application.report.dto.Response;
+
+public record TechnicalAnalysis(
+    String rsi,
+    String macd,
+    String bollingerBands,
+    String movingAverage,
+    Integer support,
+    Integer resistance,
+    String signal) {
+    public static TechnicalAnalysis onCreate(String rsi, String macd, String bollingerBands, String movingAverage,
+        Integer support, Integer resistance, String signal) {
+        return new TechnicalAnalysis(rsi, macd, bollingerBands, movingAverage, support, resistance, signal);
+    }
+}

--- a/stock-diary/src/main/java/com/ogd/stockdiary/application/report/service/ReportService.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/application/report/service/ReportService.java
@@ -1,10 +1,11 @@
 package com.ogd.stockdiary.application.report.service;
 
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 import jakarta.transaction.Transactional;
@@ -16,12 +17,14 @@ import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.chat.prompt.PromptTemplate;
 import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.ogd.stockdiary.application.report.dto.Response.BadgeResponse;
-import com.ogd.stockdiary.application.report.dto.Response.LlmResponse;
+import com.ogd.stockdiary.application.report.dto.Response.*;
+import com.ogd.stockdiary.domain.analysis.port.PromptLoader;
 import com.ogd.stockdiary.domain.principlecheck.entity.PrincipleCheckStatus;
 import com.ogd.stockdiary.domain.report.entity.Feedback;
 import com.ogd.stockdiary.domain.report.entity.RetrospectionForReport;
@@ -51,6 +54,7 @@ public class ReportService implements CreateFeedbackUseCase, GetFeedbackUsecase 
     private final ChatModel chatModel;
     private final ObjectMapper objectMapper;
     private final ReportDataPort reportDataPort;
+    private final PromptLoader promptLoader;
 
     @Override
     @Transactional
@@ -66,7 +70,7 @@ public class ReportService implements CreateFeedbackUseCase, GetFeedbackUsecase 
         BigDecimal price = retrospectionForReport.getOrder().getPrice();
         Integer volume = retrospectionForReport.getOrder().getVolume();
         OrderType orderType = retrospectionForReport.getOrder().getOrderType();
-        LocalDateTime createdAt = retrospectionForReport.getCreatedAt();
+        LocalDate date = retrospectionForReport.getCreatedAt().toLocalDate();
 
         List<ReportSourceData> reportSourceData = reportDataPort.findByRetrospectionId(command.retrospectionId());
 
@@ -95,61 +99,16 @@ public class ReportService implements CreateFeedbackUseCase, GetFeedbackUsecase 
         long notKeptCount = reportSourceData.stream()
             .filter(d -> d.status() == PrincipleCheckStatus.NOT_KEPT).count();
 
-        String userText = """
-                Please analyze the following trade data and the attached image, and provide comprehensive investment feedback based on the prompt: 'Invest'.
-
-                --- Trade Details ---
-                Symbol: {symbol}
-                Order Price: {price}
-                Order Volume: {volume}
-                Order Type: {orderType}
-                Created At: {createdAt}
-
-                --- User Reflection ---
-                Principle Check and Image Data: {principleCheckAndImage}
-            """;
-
-        // 시스템 메시지를 로더에서 불러오기
-        Message systemMessage = new SystemMessage(reportPromptLoader.getPrompt());
-
-        PromptTemplate promptTemplate = new PromptTemplate(userText);
-
-        // 플레이스 홀더, null 허용하기 위해 Map.of 대신 HashMap 사용
-        Map<String, Object> variables = new HashMap<>();
-
-        variables.put("principleCheckAndImage", principleCheckAndImage);
-        variables.put("symbol", symbol);
-        variables.put("price", price);
-        variables.put("volume", volume);
-        variables.put("orderType", orderType);
-        variables.put("createdAt", createdAt);
-
-        // 플레이스 홀더 넣은 유저 메시지 구성
-        Message userMessage = promptTemplate.createMessage(variables);
-
-        String modelName = "gpt-4.1-nano";
-
-        // 옵션: 최대 토큰 수 지정 등
-        OpenAiChatOptions options = new OpenAiChatOptions.Builder().model(modelName).maxTokens(500).build();
-
-        Prompt prompt = new Prompt(List.of(systemMessage, userMessage), options);
-
-        // 동기 처리
-        ChatResponse response = chatModel.call(prompt);
-
-        String text = response.getResult().getOutput().getText();
-
-        // JSON 문자열 text(LLM 응답)을 자바 객체로 LLM 응답용 dto 에
-        LlmResponse dto = objectMapper.readValue(text, LlmResponse.class);
+        LlmResponse llmResponse = analyzeWithMultiAgent(symbol, price, volume, orderType, date, principleCheckAndImage);
 
         // 디비에서 JSON으로 저장되는 건 다시 JSON 문자열로 변환
-        String keepJson = objectMapper.writeValueAsString(dto.keep());
-        String improveJson = objectMapper.writeValueAsString(dto.fix());
-        String nextTimeJson = objectMapper.writeValueAsString(dto.next());
+        String keepJson = objectMapper.writeValueAsString(llmResponse.keep());
+        String improveJson = objectMapper.writeValueAsString(llmResponse.fix());
+        String nextTimeJson = objectMapper.writeValueAsString(llmResponse.next());
 
         // 피드백 객체 생성
         Feedback feedback = Feedback.builder()
-            .title(dto.badge())
+            .title(llmResponse.badge())
             .keep(keepJson)
             .user(retrospection.getUser())
             .improve(improveJson)
@@ -169,6 +128,366 @@ public class ReportService implements CreateFeedbackUseCase, GetFeedbackUsecase 
 
         // 반환
         return feedback;
+
+    }
+
+    public LlmResponse analyzeWithMultiAgent(String symbol,
+        BigDecimal price,
+        Integer volume,
+        OrderType orderType,
+        LocalDate date,
+        String principleCheckAndImage) throws JsonProcessingException {
+
+        // 병렬로 리서치 진행
+        CompletableFuture<MarketData> marketDataFuture = collectMarketDataAsync(symbol, date);
+        CompletableFuture<TechnicalAnalysis> technicalAnalysisFuture = analyzeTechnicalAsync(symbol);
+        CompletableFuture<FundamentalAnalysis> fundamentalAnalysisFuture = analyzeFundamentalAsync(symbol);
+
+        // 모든 분석 완료 대기(비동기 메서드 여러 개이므로)
+        CompletableFuture.allOf(marketDataFuture, technicalAnalysisFuture, fundamentalAnalysisFuture).join();
+
+        // 리서치 객체 생성
+        Research research = synthesizeResearch(
+            marketDataFuture.join(),
+            technicalAnalysisFuture.join(),
+            fundamentalAnalysisFuture.join());
+
+        // 최종 판단
+        LlmResponse llmResponse = generateExpertJudgement(research, symbol, price, volume, orderType, date,
+            principleCheckAndImage);
+
+        return llmResponse;
+
+    }
+
+    @Async("threadPoolTaskExecutor")
+    public CompletableFuture<MarketData> collectMarketDataAsync(String symbol, LocalDate date) {
+        return CompletableFuture.supplyAsync(() -> getAndCacheMarketData(symbol, date));
+    }
+
+    @Cacheable(value = "marketData", key = "{#symbol,#date}")
+    public MarketData getAndCacheMarketData(String symbol, LocalDate date) {
+
+        try {
+            // instruction
+            String systemPrompt = """
+
+                Return structured market data by adhering strictly to the JSON format provided below.
+                Provide the analysis concisely and briefly.
+
+                Example:
+                {
+                    "symbol": "005930",
+                    "trend1w": "+2.3%",
+                    "trend1m": "-1.6%",
+                    "trend6m": "+15.4%"
+                }
+
+
+
+                """;
+
+            String userPrompt = """
+                Collect market data for {symbol} on {date}:
+                - Current price and volume
+                - 1 week, 1 month, 6 month price history
+                - Trading volume patterns
+
+                """;
+
+            PromptTemplate promptTemplate = new PromptTemplate(userPrompt);
+            Map<String, Object> variables = new HashMap<>();
+            variables.put("symbol", symbol);
+            variables.put("date", date);
+            Message userMessage = promptTemplate.createMessage(variables);
+
+            String modelName = "gpt-3.5-turbo-0125";
+            OpenAiChatOptions options = new OpenAiChatOptions.Builder().model(modelName).maxTokens(700).build();
+
+            SystemMessage systemMessage = new SystemMessage(systemPrompt);
+            Prompt prompt = new Prompt(List.of(systemMessage, userMessage), options);
+
+            // .call()은 동기 호출
+            ChatResponse response = chatModel.call(prompt);
+
+            String text = response.getResult().getOutput().getText();
+
+            // JSON 문자열 text(LLM 응답)을 자바 객체로 LLM 응답용 dto 에
+            MarketData marketDataLlmResponse = objectMapper.readValue(text, MarketData.class);
+
+            // 정적 팩토리 메서드로 인스턴스 생성
+            MarketData marketData = MarketData.onCreate(marketDataLlmResponse.symbol(), marketDataLlmResponse.trend1w(),
+                marketDataLlmResponse.trend1m(), marketDataLlmResponse.trend6m());
+
+            return marketData;
+
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Async("threadPoolTaskExecutor")
+    public CompletableFuture<TechnicalAnalysis> analyzeTechnicalAsync(String symbol) {
+        return CompletableFuture.supplyAsync(() -> getAndCacheTechnicalAnalysis(symbol));
+    }
+
+    @Cacheable(value = "technicalAnalysis", key = "{#symbol}")
+    public TechnicalAnalysis getAndCacheTechnicalAnalysis(String symbol) {
+
+        try {
+            String systemPrompt = """
+
+                Return data by adhering strictly to the JSON format provided below.
+                Provide the analysis concisely and briefly.
+
+                Example:
+                {
+                    "rsi": "65.2 (중립)",
+                    "macd": "골든크로스 형성",
+                    "bollingerBands": "상단 밴드 근접",
+                    "movingAverage": "20선 상회, 60선 돌파 대기",
+                    "support":260,
+                    "resistance":275,
+                    "signal": "매수신호"
+
+                }
+
+
+                """;
+
+            String userPrompt = """
+                Perform technical analysis for {symbol}:
+                - RSI, MACD, Bollinger Bands
+                - 20/60 day moving averages
+                - Support and resistance levels
+                - Volume analysis
+
+                Provide clear technical signals.
+
+
+                """;
+            PromptTemplate promptTemplate = new PromptTemplate(userPrompt);
+            Map<String, Object> variables = new HashMap<>();
+            variables.put("symbol", symbol);
+            Message userMessage = promptTemplate.createMessage(variables);
+
+            String modelName = "gpt-3.5-turbo-0125";
+            OpenAiChatOptions options = new OpenAiChatOptions.Builder().model(modelName).maxTokens(500).build();
+
+            Message systemMessage = new SystemMessage(systemPrompt);
+            Prompt prompt = new Prompt(List.of(systemMessage, userMessage), options);
+
+            // .call()은 동기 호출
+            ChatResponse response = chatModel.call(prompt);
+
+            String text = response.getResult().getOutput().getText();
+
+            TechnicalAnalysis technicalAnalysisLlmResponse = objectMapper.readValue(text, TechnicalAnalysis.class);
+            TechnicalAnalysis technicalAnalysis = TechnicalAnalysis.onCreate(
+                technicalAnalysisLlmResponse.rsi(),
+                technicalAnalysisLlmResponse.macd(),
+                technicalAnalysisLlmResponse.bollingerBands(),
+                technicalAnalysisLlmResponse.movingAverage(),
+                technicalAnalysisLlmResponse.support(),
+                technicalAnalysisLlmResponse.resistance(),
+                technicalAnalysisLlmResponse.signal());
+
+            return technicalAnalysis;
+
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+
+    @Async("threadPoolTaskExecutor")
+    public CompletableFuture<FundamentalAnalysis> analyzeFundamentalAsync(String symbol) {
+        return CompletableFuture.supplyAsync(() -> getAndCacheFundamentalAnalysis(symbol));
+    }
+
+    @Cacheable(value = "fundamentalAnalysis", key = "{#symbol}")
+    public FundamentalAnalysis getAndCacheFundamentalAnalysis(String symbol) {
+
+        try {
+            String systemPrompt = """
+
+                Return data by adhering strictly to the JSON format provided below.
+                Provide the analysis concisely and briefly.
+
+                Example:
+                {
+                    "earnings": "Q3 실적 예상치 상회",
+                    "peRatio": "28.5 (적정 수준)",
+                    "sectorTrend": "기술주 강세 지속",
+                    "macroFactors": "Fed 금리 동결 긍정적",
+                    "recommendation": "매수 유지"
+
+                }
+
+                """;
+
+            String userPrompt = """
+                Analyze fundamental factors for {symbol}:
+                - Recent earnings and financial health
+                - Industry trends and competitive position
+                - Macro economic factors (Fed policy, inflation)
+                - Sector performance
+
+
+                """;
+            PromptTemplate promptTemplate = new PromptTemplate(userPrompt);
+            Map<String, Object> variables = new HashMap<>();
+            variables.put("symbol", symbol);
+            Message userMessage = promptTemplate.createMessage(variables);
+
+            String modelName = "gpt-3.5-turbo-0125";
+            OpenAiChatOptions options = new OpenAiChatOptions.Builder().model(modelName).maxTokens(500).build();
+            SystemMessage systemMessage = new SystemMessage(systemPrompt);
+
+            Prompt prompt = new Prompt(List.of(systemMessage, userMessage), options);
+
+            // .call()은 동기 호출
+            ChatResponse response = chatModel.call(prompt);
+
+            String text = response.getResult().getOutput().getText();
+
+            FundamentalAnalysis fundamentalAnalysisLlmResponse = objectMapper.readValue(text,
+                FundamentalAnalysis.class);
+
+            FundamentalAnalysis analysis = FundamentalAnalysis.onCreate(fundamentalAnalysisLlmResponse.earnings(),
+                fundamentalAnalysisLlmResponse.peRatio(), fundamentalAnalysisLlmResponse.sectorTrend(),
+                fundamentalAnalysisLlmResponse.macroFactors(), fundamentalAnalysisLlmResponse.recommendation());
+
+            return analysis;
+
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public Research synthesizeResearch(MarketData marketData, TechnicalAnalysis technicalAnalysis,
+        FundamentalAnalysis fundamentalAnalysis) throws JsonProcessingException {
+
+        String systemPrompt = """
+
+            Return data by adhering strictly to the JSON format provided below.
+            Provide the analysis concisely and briefly.
+
+            Example:
+            {
+                "marketContext": "AAPL은 현재 기술적 돌파 구간에서 거래 중. 20일선 상회 후 60일선 돌파 대기 상태.",
+                "investmentThesis": "Q3 실적 호조와 AI 관련 성장 모멘텀으로 상승 여력 존재",
+                "riskFactors": "Fed 정책 변화, 중국 시장 불확실성, 고평가 우려",
+                "priceTarget": "목표가 280, 손절가 255",
+                "technicalSummary": "매수신호",
+                "fundamentalSummary": "매수 유지"
+
+
+            }
+
+
+            """;
+
+        String userPrompt = """
+            Synthesize comprehensive research report:
+
+            Market Data: {marketData}
+            Technical Analysis: {techAnalysis}
+            Fundamental Analysis: {fundAnalysis}
+
+            Create unified research summary with:
+            - Overall market context
+            - Key investment thesis
+            - Risk factors
+            - Price targets
+            """;
+
+        PromptTemplate promptTemplate = new PromptTemplate(userPrompt);
+
+        Map<String, Object> variables = new HashMap<>();
+        // JSON 포맷으로 바꾸어서 프롬프트에 넣기
+        variables.put("marketData", objectMapper.writeValueAsString(marketData));
+        variables.put("techAnalysis", objectMapper.writeValueAsString(technicalAnalysis));
+        variables.put("fundAnalysis", objectMapper.writeValueAsString(fundamentalAnalysis));
+        Message userMessage = promptTemplate.createMessage(variables);
+
+        String modelName = "gpt-3.5-turbo-0125";
+        OpenAiChatOptions options = new OpenAiChatOptions.Builder().model(modelName).maxTokens(500).build();
+
+        SystemMessage systemMessage = new SystemMessage(systemPrompt);
+        Prompt prompt = new Prompt(List.of(systemMessage, userMessage), options);
+
+        // .call()은 동기 호출
+        ChatResponse response = chatModel.call(prompt);
+
+        String text = response.getResult().getOutput().getText();
+        Research researchLlmResponse = objectMapper.readValue(text, Research.class);
+
+        Research research = Research.onCreate(
+            researchLlmResponse.marketContext(),
+            researchLlmResponse.investmentThesis(),
+            researchLlmResponse.riskFactors(),
+            researchLlmResponse.priceTarget(),
+            technicalAnalysis.signal(),
+            fundamentalAnalysis.recommendation());
+
+        return research;
+
+    }
+
+    public LlmResponse generateExpertJudgement(Research research, String symbol, BigDecimal price, Integer volume,
+        OrderType orderType, LocalDate date, String principleCheckAndImage) throws JsonProcessingException {
+
+        String userPrompt = """
+            Based on {research}:
+
+            --- Trade Details ---
+                Symbol: {symbol}
+                Order Price: {price}
+                Order Volume: {volume}
+                Order Type: {orderType}
+                date: {date}
+
+            --- User Reflection ---
+               Principle Check and Image Data: {principleCheckAndImage}
+
+
+            """;
+
+        // 시스템 메시지를 로더에서 불러오기
+        Message systemMessage = new SystemMessage(reportPromptLoader.getPrompt());
+
+        PromptTemplate promptTemplate = new PromptTemplate(userPrompt);
+
+        // 플레이스 홀더, null 허용하기 위해 Map.of 대신 HashMap 사용
+        Map<String, Object> variables = new HashMap<>();
+
+        variables.put("research", research);
+        variables.put("principleCheckAndImage", principleCheckAndImage);
+        variables.put("symbol", symbol);
+        variables.put("price", price);
+        variables.put("volume", volume);
+        variables.put("orderType", orderType);
+        variables.put("date", date);
+
+        // 플레이스 홀더 넣은 유저 메시지 구성
+        Message userMessage = promptTemplate.createMessage(variables);
+
+        // String modelName = "gpt-4.1-nano";
+        String modelName = "gpt-3.5-turbo-0125";
+
+        // 옵션: 최대 토큰 수 지정 등
+        OpenAiChatOptions options = new OpenAiChatOptions.Builder().model(modelName).maxTokens(700).build();
+
+        Prompt prompt = new Prompt(List.of(systemMessage, userMessage), options);
+
+        ChatResponse response = chatModel.call(prompt);
+        String text = response.getResult().getOutput().getText();
+
+        LlmResponse llmResponse = objectMapper.readValue(text, LlmResponse.class);
+
+        return llmResponse;
+
     }
 
     @Override

--- a/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlecheck/entity/PrincipleCheck.java
+++ b/stock-diary/src/main/java/com/ogd/stockdiary/domain/principlecheck/entity/PrincipleCheck.java
@@ -2,21 +2,7 @@ package com.ogd.stockdiary.domain.principlecheck.entity;
 
 import java.time.LocalDateTime;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.ConstraintMode;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.ForeignKey;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.PrePersist;
-import jakarta.persistence.PreUpdate;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 
 import com.ogd.stockdiary.domain.investmentprinciple.entity.InvestmentPrinciple;
 import com.ogd.stockdiary.domain.retrospection.entity.Retrospection;
@@ -25,7 +11,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "principle_checks")
+@Table(name = "principle_checks", indexes = {
+    @Index(name = "ix_principle_checks_retrospection_id", columnList = "retrospection_id")
+})
 @Getter
 @NoArgsConstructor
 public class PrincipleCheck {

--- a/stock-diary/src/main/resources/CreateFeedback.txt
+++ b/stock-diary/src/main/resources/CreateFeedback.txt
@@ -4,7 +4,7 @@ Return JSON format.
 
 2. Example of the required format:
 {
-   "badge": "bronze"
+   "badge": "bronze",
    "keep": [
               "실적 개선과 거래량 증가를 근거로 진입한 판단은 근거가 명확했습니다.",
               "매수 시점은 상승 초입 구간으로, 흐름 인식이 정확했어요."
@@ -48,4 +48,4 @@ Return JSON format.
 6. Constraints:
 - Always include all four keys: "badge", "keep", "fix", "next"
 - All content must be written in Korean.
-- "keep", "fix", "next" are 200 tokens or fewer.
+- "keep", "fix", "next" each are 300 tokens or fewer.

--- a/stock-diary/src/main/resources/application.yml
+++ b/stock-diary/src/main/resources/application.yml
@@ -55,6 +55,15 @@ spring:
     console:
       enabled: true
 
+  cache:
+    cache-names:
+      - marketData
+      - technicalAnalysis
+      - fundamentalAnalysis
+    caffeine:
+      spec: expiredAfterWrite=1h
+
+
 springdoc:
   swagger-ui:
     path: /swagger-ui.html


### PR DESCRIPTION
## 📌 관련 이슈
- Jira Ticket: [ODG-58](https://depromeet05.atlassian.net/browse/ODG-58)

## 🔍 PR의 이유
- 피드백 AI 를 멀티 에이전트로 변경 

## ✨ 주요 변경사항
- [ ] 데이터 수집 레이어: 시장 조사, 기술 조사, 기반 조사 3개 스레드를 비동기 호출, 각각 스레드는 symbol 과 date 를 인풋으로 넣음. 
- [ ] 리서치 레이어: 데이터 수집 레이어의 아웃풋을 인풋 값으로 넣음. 리서치 보고서를 생성함. 
- [ ] 피드백 레이어: 리서치 레이어의 아웃풋과 사용자의 투자원칙 관련 데이터를 함께 인풋을 넣음. 최종 피드백을 생성함. 
- [ ] 총 3개의 레이어로 구성되어있고, 5번의 API 호출을 함
- [ ] 응답 생성 시간을 단축하기 위해 비동기 호출하는 3개의 스레드에 캐시를 적용하고, AsynConfig 에서 코어 풀 사이즈를 기본값보다 크게 키움. 

## 📎 참고(선택)
- https://fancy-cosmonaut-1fc.notion.site/agentic-prompt-2a9c92d6ca8b80258b2ad97bdbb85fea